### PR TITLE
chore(harness): adopt project gate; fix scan_docs mypy union-attr

### DIFF
--- a/scripts/harness-check.sh
+++ b/scripts/harness-check.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# scripts/harness-check.sh — project pass/fail gate.
+# Called by ~/.claude/hooks/verify-before-stop.sh and `/verify`.
+# Returns non-zero on the first failed sensor.
+#
+# Customise the blocks below for your stack — uncomment, edit, or delete.
+# Keep the script fast (under ~10s) so it can run on every Stop.
+set -uo pipefail
+
+step() {
+  local label="$1"; shift
+  echo "→ $label"
+  if "$@"; then return 0; fi
+  echo "❌ harness-check failed: $label" >&2
+  exit 1
+}
+
+ran=0
+
+# Node / JS / TS.
+if [ -f package.json ]; then
+  grep -q '"lint:check"'  package.json && { step "npm run lint:check"  npm run lint:check;  ran=1; }
+  grep -q '"types:check"' package.json && { step "npm run types:check" npm run types:check; ran=1; }
+  grep -q '"test"'        package.json && { step "npm test"            npm test;            ran=1; }
+fi
+
+# PHP / Laravel.
+if [ -f composer.json ]; then
+  grep -q '"lint:check"' composer.json && { step "composer lint:check" composer lint:check; ran=1; }
+  [ -x ./vendor/bin/pint ] && { step "pint --test" ./vendor/bin/pint --test; ran=1; }
+  [ -x ./vendor/bin/phpstan ] && { step "phpstan" ./vendor/bin/phpstan analyse --no-progress; ran=1; }
+  [ -x ./vendor/bin/pest ] && { step "pest" ./vendor/bin/pest; ran=1; }
+  [ -x ./vendor/bin/phpunit ] && [ ! -x ./vendor/bin/pest ] && { step "phpunit" ./vendor/bin/phpunit; ran=1; }
+fi
+
+# Python.
+if [ -f pyproject.toml ]; then
+  command -v ruff   >/dev/null 2>&1 && { step "ruff check" ruff check .; ran=1; }
+  command -v mypy   >/dev/null 2>&1 && { step "mypy"       mypy .;       ran=1; }
+  # pytest exit 5 = no tests collected; treat as PASS until the suite exists.
+  command -v pytest >/dev/null 2>&1 && { step "pytest"     bash -c 'pytest; rc=$?; [ $rc -eq 5 ] && exit 0; exit $rc'; ran=1; }
+fi
+
+# Go.
+[ -f go.mod ] && { step "go vet"  go vet ./...;  step "go test" go test ./...; ran=1; }
+
+# Rust.
+[ -f Cargo.toml ] && { step "cargo check" cargo check; step "cargo test" cargo test; ran=1; }
+
+# Ruby / Rails.
+if [ -f Gemfile ]; then
+  [ -x ./bin/rubocop ]  && { step "rubocop" ./bin/rubocop;  ran=1; }
+  [ -x ./bin/rspec ]    && { step "rspec"   ./bin/rspec;    ran=1; }
+fi
+
+if [ $ran -eq 0 ]; then
+  echo "harness-check: no sensors fired."
+  echo "  → edit scripts/harness-check.sh to wire your project's lint / types / tests."
+  echo "  → an empty harness-check is treated as PASS so this script doesn't strand Stop."
+  exit 0
+fi
+
+echo "✅ harness-check passed"

--- a/skills/audit-docs/scripts/scan_docs.py
+++ b/skills/audit-docs/scripts/scan_docs.py
@@ -634,12 +634,13 @@ def agent_readiness(root: Path, md_files: list[Path]) -> dict[str, Any]:
                 bare_blocks += 1
             if body.count("\n") < 3 and ("..." in body or "# ..." in body):
                 likely_incomplete.append({"path": rel, "snippet": body.strip()[:80]})
-            if REAL_LOOKING_KEY.search(body):
+            key_match = REAL_LOOKING_KEY.search(body)
+            if key_match:
                 copy_paste_findings.append(
                     {
                         "path": rel,
                         "issue": "real-looking secret/key in code block",
-                        "snippet": REAL_LOOKING_KEY.search(body).group(0)[:40],
+                        "snippet": key_match.group(0)[:40],
                     }
                 )
 


### PR DESCRIPTION
## Summary

Retrofits the user-scope harness into this project and fixes a latent mypy error surfaced by the new gate.

## Issue

Running `verify-before-stop.sh` (the user-scope Stop hook) had nothing to call — there was no project pass/fail gate. Once the gate landed, `mypy .` flagged a real `union-attr` bug in `skills/audit-docs/scripts/scan_docs.py`.

## Cause

- No `scripts/harness-check.sh` existed, so the Stop hook had no contract to verify against.
- `scan_docs.py:642` called `.group(0)` on `REAL_LOOKING_KEY.search(body)` without binding the match to a variable. The second `.search()` call could return `None`, which mypy correctly rejects under `union-attr`.

## Fix

- **`scripts/harness-check.sh`** (new) — stack-aware project gate written by `/harness adopt`. Runs `ruff check`, `mypy`, and `pytest` for this Python project. Pytest exit code 5 ("no tests collected") is treated as PASS with an inline rationale, so the gate doesn't strand `Stop` until the suite exists.
- **`skills/audit-docs/scripts/scan_docs.py:637-644`** — bind the regex result to `key_match` once and guard with a truthiness check before reading `.group(0)`. Behaviour is unchanged; the type-narrowing is now explicit.

## Validation

- `ruff check` — clean
- `mypy` — `Success: no issues found in 6 source files`
- `pytest` — no tests collected (expected, gate treats as PASS)
- Full `scripts/harness-check.sh` run reports `✅ harness-check passed`
