### PR TITLE
chore(harness): add shellcheck step to harness-check.sh

### DIFF
--- a/scripts/harness-check.sh
+++ b/scripts/harness-check.sh
@@ -33,6 +33,15 @@ if [ -f composer.json ]; then
   [ -x ./vendor/bin/phpunit ] && [ ! -x ./vendor/bin/pest ] && { step "phpunit" ./vendor/bin/phpunit; ran=1; }
 fi
 
+# Shell — match CI: shellcheck every .sh under skills/harness, same exclusions.
+if command -v shellcheck >/dev/null 2>&1 && \
+   compgen -G "skills/harness/scripts/*.sh" >/dev/null; then
+  step "shellcheck" shellcheck -e SC2155,SC2034 \
+    skills/harness/scripts/*.sh \
+    skills/harness/assets/hooks/*.sh
+  ran=1
+fi
+
 # Python.
 if [ -f pyproject.toml ]; then
   command -v ruff   >/dev/null 2>&1 && { step "ruff check" ruff check .; ran=1; }


### PR DESCRIPTION
## Summary

Brings the local `scripts/harness-check.sh` gate into parity with the CI `shellcheck` job in `.github/workflows/skill-harness.yml`, so a clean local `/verify` reflects what CI will actually run.

## Issue

`scripts/harness-check.sh` (added in #2) ran `ruff`, `mypy`, and `pytest` but did not invoke `shellcheck`. CI does — every push runs `shellcheck -e SC2155,SC2034` over `skills/harness/scripts/*.sh` and `skills/harness/assets/hooks/*.sh`. Local Stop / `/verify` could pass while CI later failed on shell lint.

## Cause

The starter written by `/harness adopt` only knows about the manifest-detected stack (Python here), so it never enabled a shell-lint sensor. The shell scripts under `skills/harness/` are the project's product surface, not incidental tooling, so they belong in the gate.

## Fix

`scripts/harness-check.sh` — new block before the Python sensors:

```bash
if command -v shellcheck >/dev/null 2>&1 && \
   compgen -G "skills/harness/scripts/*.sh" >/dev/null; then
  step "shellcheck" shellcheck -e SC2155,SC2034 \
    skills/harness/scripts/*.sh \
    skills/harness/assets/hooks/*.sh
  ran=1
fi
```

- Same `-e SC2155,SC2034` exclusions as CI (`.github/workflows/skill-harness.yml:24`).
- Same paths as CI (`skills/harness/scripts/*.sh` + `skills/harness/assets/hooks/*.sh`).
- Guarded by `command -v shellcheck` and a `compgen -G` glob check, so contributors without shellcheck installed skip cleanly and the script remains usable in fresh clones.

## Validation

```
$ bash scripts/harness-check.sh
→ shellcheck
→ ruff check
All checks passed!
→ mypy
Success: no issues found in 6 source files
→ pytest
collected 0 items
✅ harness-check passed
```

Local gate now mirrors CI shell-lint coverage.
