### PR TITLE
docs(harness): add spatial-vs-temporal context taxonomy

### DIFF
--- a/skills/harness/README.md
+++ b/skills/harness/README.md
@@ -26,7 +26,7 @@ This skill is also a sibling of [datashaman/harness-template](https://github.com
 
 ## Context model: spatial vs temporal
 
-The harness manages context on two axes. Naming them gives design discussions vocabulary ("is this a spatial concern or a temporal one?") and makes coverage gaps visible at a glance. Hooks aren't on either table — they're *sensors* (feedback), not context surfaces; they're documented under install below.
+The harness manages context on two axes. Naming them gives design discussions vocabulary ("is this a spatial concern or a temporal one?") and makes coverage gaps visible at a glance. Most hooks are *sensors* on the feedback axis — they're documented under install below, not here. The one exception is `post-compact-reinject.sh`: implemented as a hook, but its job is *context preservation*, so it sits in the temporal table.
 
 **Spatial — what occupies the window in a given turn:**
 
@@ -34,6 +34,7 @@ The harness manages context on two axes. Naming them gives design discussions vo
 | ----------------------- | ----------------------------- | ------------------------------------------------------------------ |
 | `~/.claude/CLAUDE.md`   | yes                           | user-scope operating contract                                      |
 | `<project>/CLAUDE.md`   | yes (when in that project)    | project-scope override                                             |
+| `<project>/AGENTS.md`   | yes (when present)            | sibling to project CLAUDE.md; re-injected after autocompact        |
 | `MEMORY.md` (index)     | yes                           | pointers to memory entries, not the entries themselves             |
 | Memory entries          | on demand                     | loaded when the agent decides they're relevant                     |
 | Skills                  | on demand                     | progressive disclosure — `SKILL.md` frontmatter triggers the load  |

--- a/skills/harness/README.md
+++ b/skills/harness/README.md
@@ -24,6 +24,34 @@ The day-to-day patterns this skill ships came from these voices, who keep publis
 
 This skill is also a sibling of [datashaman/harness-template](https://github.com/datashaman/harness-template) — that repo is the *project-scope* harness (drop-in stack profiles, `harness/policies/`, `scripts/harness-check.sh`, `harness/grades.yml`). `/harness` is the user-scope counterpart.
 
+## Context model: spatial vs temporal
+
+The harness manages context on two axes. Naming them gives design discussions vocabulary ("is this a spatial concern or a temporal one?") and makes coverage gaps visible at a glance. Hooks aren't on either table — they're *sensors* (feedback), not context surfaces; they're documented under install below.
+
+**Spatial — what occupies the window in a given turn:**
+
+| Surface                 | Always loaded?                | Notes                                                              |
+| ----------------------- | ----------------------------- | ------------------------------------------------------------------ |
+| `~/.claude/CLAUDE.md`   | yes                           | user-scope operating contract                                      |
+| `<project>/CLAUDE.md`   | yes (when in that project)    | project-scope override                                             |
+| `MEMORY.md` (index)     | yes                           | pointers to memory entries, not the entries themselves             |
+| Memory entries          | on demand                     | loaded when the agent decides they're relevant                     |
+| Skills                  | on demand                     | progressive disclosure — `SKILL.md` frontmatter triggers the load  |
+| System prompt           | yes                           | tools + harness instructions                                       |
+
+**Temporal — what survives across boundaries:**
+
+| Boundary                          | Mechanism                                                                         |
+| --------------------------------- | --------------------------------------------------------------------------------- |
+| Autocompact (mid-session)         | `post-compact-reinject.sh` — re-cats `CLAUDE.md` / `AGENTS.md` / `~/.claude/CLAUDE.md` |
+| Between tool steps (mid-session)  | `/critique` — deliberate critique pass without waiting for Stop (PTC, see #6)     |
+| Session end → next session        | auto-memory write — agent stores durable facts to `memory/`                       |
+| Across sessions                   | `memory/` store + `MEMORY.md` index                                               |
+| Memory hygiene over time          | `memoize` sub-action (deterministic) + weekly remote routine (semantic)           |
+| Config drift over time            | `snapshot` (mirror to private repo) + monthly remote `audit` routine              |
+
+The PTC loop named in `CLAUDE.md` cuts across these axes: **Plan** is spatial preparation (load the right context before editing), **Tool** is the work itself, **Critique** is *temporal* — carrying findings forward, at session boundaries (Stop gate, `advisor()`) and intra-session via `/critique`.
+
 ## When to use
 
 `/harness` — the skill detects intent from your phrasing. Examples:


### PR DESCRIPTION
## Summary

Closes #7. Adds a "Context model: spatial vs temporal" section to `skills/harness/README.md`, naming the two axes the harness already manages and tabling every existing surface against them.

## What changed

- **`skills/harness/README.md`** — new section between `## Where the idea comes from` and `## When to use`. Two tables (spatial / temporal) plus a short framing paragraph and a closing paragraph that locates the PTC loop on both axes.
- No behaviour change. No edits to scripts, `SKILL.md`, `CLAUDE.md.tmpl`, or any other file.

## Why

The harness already manages context on two axes — *spatial* (CLAUDE.md, MEMORY.md index, loaded skills, system prompt) and *temporal* (post-compact-reinject, auto-memory, `memoize`, snapshot, monthly audit). We didn't *name* them that way, so design discussions had no shared vocabulary and gaps weren't visible at a glance. Naming the axes is pure docs leverage — no cost, makes future coverage decisions easier.

## Deviations from issue #7's draft

- **Memory hygiene row.** Issue #7 listed it as `(gap) memory rot — see #5`. #5 shipped (`memoize` sub-action via PR #8) before this work, so the row now reads "filled by `memoize` (deterministic) + weekly remote routine (semantic)" instead of being a gap.
- **Added a row for intra-session temporal context.** `/critique` (#6 / PR #9) is a temporal surface inside a single session — between tool steps. Not in the original draft tables but it belongs there now that the surface exists.
- **Hooks deliberately excluded from both tables.** Hooks are sensors on the feedback axis, not context surfaces — explicitly noted in the framing paragraph so a careful reader doesn't expect them.

## Validation

- `./scripts/harness-check.sh` passes (shellcheck, ruff, mypy, pytest).
- Tables cross-checked against `skills/harness/SKILL.md` and the install matrix in the README — every spatial/temporal surface that exists is listed; nothing fabricated.
- advisor() pass before commit caught two framing tensions that landed in the diff: removed a forward-reference to a non-existent "feedback axis" section, and dropped the `verify-before-stop.sh` callout from the closing PTC paragraph (it conflicted with the "hooks aren't context" framing right above it).
