### PR TITLE
Add /onepager skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,22 @@ Builds on [OpenAI's harness-engineering article](https://openai.com/index/harnes
 /harness audit              # prep a monthly remote routine
 ```
 
+### `/onepager`
+
+Generate a self-contained single-file HTML demo or presentation using Alpine.js + Tailwind via CDN. Emailable, double-clickable, no build step. Aimed at business and marketing users putting an interactive thing in front of a stakeholder without booking engineering — the agent makes all edits, the user only opens the file in a browser.
+
+Ships with four reference patterns the skill draws on: a baseline list-with-details demo, a KPI dashboard with a coaching-mark tour (spotlight overlay, `$persist`-backed "tour seen" state), a keyboard-driven slide deck with five layouts (cover, bullets, metric, quote, code), and a simulated-AI inbox with thinking-step trace and word-by-word streaming. Live worked examples at [datashaman/alpine-onepager](https://github.com/datashaman/alpine-onepager).
+
+**Arguments:** None — drop a topic in natural language and the skill produces the file.
+
+**Usage:**
+```
+/onepager a demo of our pricing tiers
+/onepager Q1 business review slide deck
+/onepager walkthrough of our onboarding flow with coaching marks
+/onepager a simulated AI assistant for support triage
+```
+
 ## Other skills I like
 
 ### [`agent-ready-codebase`](https://skills.sh/casper-studios/casper-marketplace/agent-ready-codebase)

--- a/skills/onepager/README.md
+++ b/skills/onepager/README.md
@@ -1,0 +1,57 @@
+# onepager
+
+**Single-file Alpine.js + Tailwind demos and presentations** — emailable, double-clickable, no build step. The skill writes one HTML file you can open straight in a browser.
+
+Aimed at business and marketing users who need to put an interactive thing in front of a client, stakeholder, or colleague without booking engineering. The agent makes all edits; the user only opens the file in a browser to see the result.
+
+## When to use
+
+Good prompts: *make a demo*, *build a one-pager*, *prototype this*, *slide deck*, *interactive mockup*, *walkthrough*, *pitch*. Drop a topic ("a demo of our pricing tiers", "a Q1 review deck", "show what our agent does") and the skill produces the file.
+
+Don't use for production apps, multi-page sites, or anything that needs a real backend, auth, or persistence beyond `localStorage`.
+
+## Arguments
+
+None. The skill takes a freeform topic in natural language.
+
+**Usage:**
+```
+/onepager a demo of our pricing tiers
+/onepager Q1 business review slide deck
+/onepager a walkthrough of our onboarding flow with coaching marks
+```
+
+## What you get
+
+One HTML file with:
+
+- **Alpine.js 3** for reactivity (`x-data`, `x-model`, `x-for`, `x-show`, `x-transition`)
+- **Tailwind Play CDN** for styling — no PostCSS pipeline
+- **One root `x-data` block** holding all state, with getters as computed properties
+- **Inline teaching comments** explaining each Alpine directive (the file is also a teaching artifact)
+- An empty state for every list and detail pane, soft transitions on appear/disappear, and tabular numerics on number columns
+
+## Files in this folder
+
+| File          | Role                                                                                |
+| ------------- | ----------------------------------------------------------------------------------- |
+| `SKILL.md`    | Full agent instructions: hard rules, conventions, mode-specific patterns, checklist |
+| `README.md`   | This overview                                                                       |
+| `references/` | Four canonical patterns the skill references                                        |
+
+## Reference patterns
+
+| File                                  | Pattern                                                                                                |
+| ------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| `references/catalogue.html`           | Baseline list-with-details: search + filter + sort + detail pane + empty state                         |
+| `references/dashboard-with-tour.html` | KPI dashboard with coaching-mark tour (spotlight overlay, `getBoundingClientRect`, `$persist` plugin)  |
+| `references/slide-deck.html`          | Keyboard-driven slide deck — five layouts (cover, bullets, metric, quote, code), notes, fullscreen     |
+| `references/streaming-ai.html`        | Simulated AI: thinking-step trace, word-by-word streaming reply, regenerate / edit / accept            |
+
+## Graduation signals
+
+The skill flags these to the user when the demo starts wanting them:
+
+- `@alpinejs/persist` plugin for `localStorage`-backed state (one extra script tag).
+- petite-vue or full Vue 3 from CDN for component decomposition without a build step.
+- A real backend + framework once the single-file format stops paying for itself (~1500 line soft ceiling).

--- a/skills/onepager/SKILL.md
+++ b/skills/onepager/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: onepager
+description: |
+  Generate a self-contained single-file HTML demo or presentation
+  using Alpine.js + Tailwind via CDN. Emailable, double-clickable, no
+  build step or server. Use when the user asks for a demo, prototype,
+  slide deck, walkthrough, pitch, or interactive mockup. Triggers on
+  phrases like "make a demo", "build a one-pager", "prototype this",
+  "presentation/slides", "single-file HTML", or "no build step".
+user-invocable: true
+---
+
+# Onepager — single-file demo & presentation generator
+
+Produce one HTML file. No `package.json`, no bundler, no server, no separate JS/CSS files. The output must run by double-clicking it (or `open file.html`) with only an internet connection for the CDN scripts.
+
+## Reference examples
+
+Four canonical patterns live alongside this file in `references/`. Read whichever matches the request before you start writing — they encode all the conventions below as working code.
+
+- `references/catalogue.html` — the baseline demo pattern: search + filter + sort + detail pane + empty state. Start here for any list-with-details ask.
+- `references/dashboard-with-tour.html` — KPI dashboard with a coaching-mark tour (spotlight overlay, `getBoundingClientRect` measurement, persisted "tour seen" via the `$persist` plugin).
+- `references/slide-deck.html` — keyboard-driven slide deck with five layouts (cover, bullets, metric, quote, code), speaker notes, fullscreen mode.
+- `references/streaming-ai.html` — simulated AI: thinking-step trace, word-by-word streaming reply, regenerate / edit / accept controls, `runId` to abort stale streams.
+
+## Who you are talking to
+
+Assume the person invoking this skill is a **business or marketing user** — comfortable with computers and willing to open a file in a text editor or run `open foo.html`, but **not a developer**. They are using this to put a working interactive thing in front of a client, a stakeholder, or a colleague — without booking a sprint with engineering.
+
+What that means for you:
+
+- **No jargon without translation.** If you mention `x-data`, `getter`, `$persist`, or a CDN, give a one-line "this means…" the first time. The teaching comments inside the HTML do this; your chat replies should too.
+- **Default to "I'll just do it"** for anything that needs a code change. Don't ask "do you want me to add a getter for the filtered list?" — they don't know. Decide and do; describe what you did in plain language afterwards.
+- **You make the edits, not them.** Never tell the user to open the file and change a line, replace an array, or paste a snippet. If something needs changing, change it yourself with the editing tools. The user's only interaction with the file should be opening it in a browser to look at the result.
+- **Talk about outcomes, not implementations.** "I added a search box that filters as you type" beats "I bound `x-model` to a reactive `search` property and added a `filteredItems` getter." Reserve the second form for inline code comments.
+- **Don't suggest dev workflow changes.** No "add a test", "run the linter", "set up CI", "convert to TypeScript". They are not running any of that.
+- **Be generous with realistic sample data.** They'll often hand you a topic ("a demo of our pricing tiers") rather than data. Invent plausible content; they will replace it (by asking you, not by editing). Aim for content that looks like a real customer's, not lorem ipsum.
+- **When you need their content, ask in plain English.** "Got the pricing tiers and what each includes? Paste them in and I'll wire them in." Not "provide the `items` array in JSON."
+
+This is not a reason to dumb anything down. The output is still a properly built, idiomatic Alpine app — it just needs to *land* without a developer in the loop.
+
+## When to use this skill
+
+Use it for:
+- **Demos / prototypes** — interactive UI to show an idea (catalogue, dashboard, form flow, data explorer).
+- **Presentations / slide decks** — keyboard-navigable slides with transitions, speaker notes, progress.
+- **Walkthroughs / tutorials** — step-by-step guided UI, often with a "next" button advancing state.
+- **Pitches / explainers** — landing-page-style narrative scrolls with reactive bits.
+
+Do **not** use it for:
+- Anything needing real persistence, auth, server-side logic, or a real backend.
+- Multi-page apps, routing-heavy UIs, or anything where one file becomes unwieldy (>~1500 lines is the soft ceiling — flag this to the user).
+- Production apps. This is a starter, not a destination.
+
+## Hard rules
+
+1. **One file.** All markup, state, styles, and data live in the single `.html` you output. Never split.
+2. **CDN only, no install.** Use these exact tags in `<head>`:
+   ```html
+   <script src="https://cdn.tailwindcss.com"></script>
+   <script defer src="https://unpkg.com/alpinejs@3.14.1/dist/cdn.min.js"></script>
+   ```
+   `defer` on Alpine is required.
+3. **One root `x-data` block** holds the entire app's reactive state. Nested `x-data` only when scoping is genuinely needed (e.g. a repeated component with local state).
+4. **Use getters as computed properties** — `get filteredItems()` rather than recomputing in templates. Alpine re-runs them automatically.
+5. **`x-cloak` on the root** plus `[x-cloak]{display:none!important}` in a `<style>` to prevent the un-hydrated flash.
+6. **Tabular numerics** (`tabular-nums`) on price/count columns. Small detail, big polish.
+7. **Comment the Alpine concepts inline** the way `references/catalogue.html` does (`x-model is two-way binding`, `x-for renders one element per array item`, etc.). The output is a teaching artifact as much as a working demo.
+8. **No emojis** in the output unless the user asked for them.
+
+## Conventions to follow
+
+- **Tailwind palette**: default to `slate` for neutrals, white cards on `bg-slate-50`, `border-slate-200/300`, `text-slate-500/700/900`. Avoid gradient soup and rainbow accents — keep it editorial.
+- **Spacing**: `mx-auto max-w-6xl px-6 py-10` for the page container is a sensible default.
+- **Typography**: `tracking-tight` on headings, `font-semibold` (not `font-bold`), `antialiased` on body.
+- **Transitions**: prefer `x-transition` with explicit `enter`/`leave` classes for anything that appears/disappears. Defaults are too snappy.
+- **Empty states**: every list and detail pane should have one. Dashed border, muted text, helpful sentence.
+- **Keyboard**: for presentations, wire `@keydown.arrow-right.window` / `arrow-left` / `space` on the root. For demos, at minimum support `Escape` to close modals/panes.
+
+## Presentation-mode specifics
+
+When the request is a slide deck:
+- State shape: `{ slide: 0, slides: [...] }` where each slide is `{ title, body, notes? }` or a discriminated `{ type: 'cover' | 'bullets' | 'image' | 'code', ... }`.
+- Render exactly one slide at a time via `x-show` + `x-transition` keyed on `slide` index.
+- Show `slide + 1 / slides.length` in a corner.
+- Bind keys: `→`/`Space` advances, `←` retreats, `Home`/`End` jump, `f` toggles a `fullscreen` boolean that hides chrome.
+- Speaker notes hidden by default, toggleable with `n`.
+- Progress bar at the top: `width: ((slide+1) / slides.length * 100) + '%'`.
+
+## Demo-mode specifics
+
+When the request is an interactive demo:
+- Sample data goes in an `items` (or domain-appropriate) array at the top of `x-data`. Provide 12–20 realistic-looking entries — enough to make filter/sort feel meaningful, not so many the file bloats.
+- Always include: a search/filter control, a sort control, a list, a detail pane (or modal), and an empty state. This is the load-bearing pattern from `references/catalogue.html` and it scales to most demo asks.
+- Selection state lives at the root (`selected: null`), not inside the loop.
+
+## Offer an onboarding flow
+
+After delivering a non-trivial demo, **offer to add a coaching-mark / onboarding tour** as a follow-up. Don't add it unprompted — surface it as a one-line question: *"Want me to wire up a coaching-mark tour for this?"*. Most demos benefit, but unsolicited additions inflate scope.
+
+When the user accepts, the pattern from `references/dashboard-with-tour.html` is the reference:
+
+- **State**: `tour: { active: false, step: 0 }` plus a `tourSteps` array of `{ target, title, body, placement, autoSelect? }` entries. `target` matches a `data-tour="..."` attribute on a real DOM element. `placement` is `'top' | 'bottom' | 'left' | 'right'`. `autoSelect` is optional — opens a drawer / picks an item before measuring, so the spotlight can land on dynamically-revealed UI.
+- **Spotlight**: a single fixed-position div with `box-shadow: 0 0 0 9999px rgba(15, 23, 42, 0.72)` and no background. The shadow dims everything outside the box; transitions on `top/left/width/height` animate between targets cheaply. Crisper than an SVG mask.
+- **Coaching card**: another fixed div positioned next to the spotlight using the step's `placement`. Title, body, step counter (`n / total`), Back / Next / Skip controls.
+- **Measurement**: `measureTarget()` calls `getBoundingClientRect()` on the active step's `data-tour` element, with `scrollIntoView({ block: 'center', behavior: 'smooth' })` first. Re-measure on `resize` and `scroll` so the spotlight tracks. Use `$nextTick` after step changes so DOM updates from `autoSelect` settle before measuring.
+- **Keyboard**: `Escape` ends the tour, `ArrowRight` / `Enter` advances, `ArrowLeft` retreats.
+- **Annotation in HTML**: sprinkle `data-tour="some-id"` attributes on the elements steps point at. Identifiers should be lowercase-kebab and unique. Bind dynamically with `:data-tour="'item-' + i.id"` when targeting list rows.
+- **Don't block clicks** on the spotlit element — `pointer-events: none` on the spotlight, with a transparent click-trap overlay behind it that catches outside clicks and ends the tour.
+
+For lighter onboarding (one-shot welcome panels, dismissible tooltips), a single `<div x-show="!seenWelcome">` with a localStorage check via `$persist` is enough — don't reach for the full tour machinery.
+
+## Output checklist (run mentally before handing back)
+
+- [ ] Doctype, lang, viewport, charset, title set.
+- [ ] Tailwind + Alpine CDN tags in `<head>`, Alpine has `defer`.
+- [ ] `x-cloak` style block present and applied to root.
+- [ ] All reactive state in one `x-data` (or justified nested ones).
+- [ ] Getters used for derived data, not inline computations.
+- [ ] At least one `x-transition` somewhere — UIs without motion feel dead.
+- [ ] Empty state for every list / detail region.
+- [ ] Tasteful comments explaining the Alpine directives, matching `references/catalogue.html`'s tone.
+- [ ] No build artifacts, no `<link rel="stylesheet">` to local files, no `<script src="./...">`.
+- [ ] Opens cleanly with `open foo.html` — verify mentally that nothing assumes a server origin (no `fetch` to relative URLs, no module scripts).
+
+## Graduation signals (mention these to the user when relevant)
+
+If the demo grows past ~1500 lines, needs persistence, needs multiple pages, or starts wanting components, surface the upgrade path:
+- `$persist` plugin for localStorage-backed state (one extra script tag — already in `references/dashboard-with-tour.html`).
+- petite-vue or full Vue 3 from CDN for component decomposition without a build step.
+- An actual backend + framework when the single-file format stops paying for itself.

--- a/skills/onepager/references/catalogue.html
+++ b/skills/onepager/references/catalogue.html
@@ -1,0 +1,245 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Reactive HTML Starter — Alpine.js</title>
+
+  <!-- Tailwind via Play CDN: gives you utility classes with no build step. -->
+  <script src="https://cdn.tailwindcss.com"></script>
+
+  <!-- Alpine.js v3 via CDN. `defer` is required so Alpine waits for the DOM
+       before scanning for x-* directives. -->
+  <script defer src="https://unpkg.com/alpinejs@3.14.1/dist/cdn.min.js"></script>
+
+  <style>
+    [x-cloak] { display: none !important; }
+    body { font-feature-settings: "ss01", "cv11"; }
+  </style>
+</head>
+<body class="bg-slate-50 text-slate-900 antialiased">
+
+<!--
+  THE WHOLE APP LIVES INSIDE ONE x-data BLOCK.
+  Everything in the returned object becomes reactive: change a value and any
+  attribute/text bound to it re-renders automatically. No event listeners,
+  no manual DOM updates, no framework concepts beyond this.
+-->
+<div
+  x-cloak
+  x-data="{
+    /* --- Sample data: replace this array with your own. --- */
+    items: [
+      { id: 1,  name: 'Aurora Headphones',     category: 'Audio',     price: 249, tags: ['wireless','over-ear'],   blurb: 'Active noise cancelling over-ears with 40h battery.' },
+      { id: 2,  name: 'Pebble Earbuds',        category: 'Audio',     price: 129, tags: ['wireless','in-ear'],     blurb: 'Compact buds with adaptive EQ and a tiny charging case.' },
+      { id: 3,  name: 'Loft Bookshelf Speaker',category: 'Audio',     price: 379, tags: ['stereo','wired'],        blurb: 'Warm-sounding bookshelf speakers, sold as a stereo pair.' },
+      { id: 4,  name: 'Halo Smart Bulb',       category: 'Lighting',  price: 29,  tags: ['smart-home','colour'],   blurb: 'Tunable white plus 16M colours, no hub required.' },
+      { id: 5,  name: 'Beam Floor Lamp',       category: 'Lighting',  price: 189, tags: ['ambient','dimmable'],    blurb: 'Brushed-brass floor lamp with a stepless dimmer.' },
+      { id: 6,  name: 'Pulse Desk Light',      category: 'Lighting',  price: 95,  tags: ['task','dimmable'],       blurb: 'Articulating task light with a high-CRI LED panel.' },
+      { id: 7,  name: 'Drift Office Chair',    category: 'Furniture', price: 549, tags: ['ergonomic','mesh'],      blurb: 'Mesh-back ergonomic chair with adjustable lumbar.' },
+      { id: 8,  name: 'Plank Standing Desk',   category: 'Furniture', price: 799, tags: ['adjustable','oak'],      blurb: 'Solid oak top, dual-motor electric height adjust.' },
+      { id: 9,  name: 'Nook Lounge Chair',     category: 'Furniture', price: 690, tags: ['lounge','wool'],         blurb: 'Wool-blend lounge chair on a solid ash frame.' },
+      { id: 10, name: 'Atlas Mechanical Keyboard', category: 'Desk',  price: 159, tags: ['mechanical','75%'],      blurb: 'Hot-swap 75% layout with PBT caps and tactile switches.' },
+      { id: 11, name: 'Glide Trackpad',        category: 'Desk',      price: 119, tags: ['wireless','multitouch'], blurb: 'Large glass trackpad with haptic click and USB-C.' },
+      { id: 12, name: 'Spool Cable Tray',      category: 'Desk',      price: 39,  tags: ['organiser','steel'],     blurb: 'Under-desk steel tray for taming power and data cables.' },
+      { id: 13, name: 'Brew Pour-Over Kit',    category: 'Kitchen',   price: 65,  tags: ['glass','manual'],        blurb: 'Glass dripper, server, and reusable steel filter.' },
+      { id: 14, name: 'Crust Bread Knife',     category: 'Kitchen',   price: 89,  tags: ['serrated','steel'],      blurb: 'Forged serrated knife that handles sourdough crusts effortlessly.' },
+      { id: 15, name: 'Ember Cast Pan',        category: 'Kitchen',   price: 119, tags: ['cast-iron','seasoned'],  blurb: 'Pre-seasoned cast iron pan, oven-safe to 260C.' },
+      { id: 16, name: 'Ridge Travel Backpack', category: 'Bags',      price: 219, tags: ['carry-on','water-resistant'], blurb: '35L carry-on backpack with a clamshell main compartment.' },
+      { id: 17, name: 'Field Messenger Bag',   category: 'Bags',      price: 179, tags: ['canvas','laptop'],       blurb: 'Waxed canvas messenger sized for a 15-inch laptop.' },
+      { id: 18, name: 'Coast Sling',           category: 'Bags',      price: 79,  tags: ['compact','everyday'],    blurb: 'Compact sling with quick-access pockets for daily essentials.' }
+    ],
+
+    /* --- UI state. Mutating any of these re-renders the bound DOM. --- */
+    search: '',
+    category: 'all',
+    sortBy: 'name',
+    selected: null,
+
+    /* Getters act like computed properties: they re-evaluate whenever any
+       reactive value they read changes. */
+    get categories() {
+      return ['all', ...new Set(this.items.map(i => i.category))].sort();
+    },
+    get filteredItems() {
+      const q = this.search.trim().toLowerCase();
+      let out = this.items.filter(i => {
+        const matchesCat = this.category === 'all' || i.category === this.category;
+        if (!matchesCat) return false;
+        if (!q) return true;
+        return (
+          i.name.toLowerCase().includes(q) ||
+          i.category.toLowerCase().includes(q) ||
+          i.tags.some(t => t.toLowerCase().includes(q))
+        );
+      });
+      const cmp = {
+        name:       (a, b) => a.name.localeCompare(b.name),
+        priceAsc:   (a, b) => a.price - b.price,
+        priceDesc:  (a, b) => b.price - a.price,
+        category:   (a, b) => a.category.localeCompare(b.category) || a.name.localeCompare(b.name)
+      }[this.sortBy];
+      return out.sort(cmp);
+    },
+
+    /* Methods are just functions on the state object. */
+    select(item) { this.selected = item; },
+    clear()      { this.search = ''; this.category = 'all'; this.sortBy = 'name'; this.selected = null; },
+
+    /* Tiny helper for the price column. */
+    money(n) { return '$' + n.toFixed(0); }
+  }"
+  class="mx-auto max-w-6xl px-6 py-10"
+>
+
+  <!-- Header -->
+  <header class="flex items-end justify-between mb-8 gap-4 flex-wrap">
+    <div>
+      <h1 class="text-3xl font-semibold tracking-tight">Catalogue</h1>
+      <!-- x-text binds element text to a reactive expression. The count
+           updates automatically whenever filteredItems changes. -->
+      <p class="text-slate-500 mt-1">
+        Showing <span class="font-medium text-slate-900" x-text="filteredItems.length"></span>
+        of <span x-text="items.length"></span> items
+      </p>
+    </div>
+    <button
+      @click="clear()"
+      class="text-sm px-3 py-2 rounded-md border border-slate-300 bg-white hover:bg-slate-100 transition"
+    >Clear filters</button>
+  </header>
+
+  <!-- Controls -->
+  <section class="grid grid-cols-1 md:grid-cols-3 gap-3 mb-6">
+    <!-- x-model is two-way binding: typing here updates state.search, and
+         anything that reads state.search re-renders. -->
+    <input
+      type="search"
+      x-model="search"
+      placeholder="Search by name, category, or tag…"
+      class="md:col-span-1 rounded-md border border-slate-300 bg-white px-3 py-2 focus:outline-none focus:ring-2 focus:ring-slate-900/10"
+    >
+
+    <!-- x-model on a <select> binds to the chosen value. The <option> list
+         is generated reactively from the categories getter. -->
+    <select
+      x-model="category"
+      class="rounded-md border border-slate-300 bg-white px-3 py-2 focus:outline-none focus:ring-2 focus:ring-slate-900/10"
+    >
+      <template x-for="c in categories" :key="c">
+        <option :value="c" x-text="c === 'all' ? 'All categories' : c"></option>
+      </template>
+    </select>
+
+    <select
+      x-model="sortBy"
+      class="rounded-md border border-slate-300 bg-white px-3 py-2 focus:outline-none focus:ring-2 focus:ring-slate-900/10"
+    >
+      <option value="name">Sort: Name (A–Z)</option>
+      <option value="priceAsc">Sort: Price (low to high)</option>
+      <option value="priceDesc">Sort: Price (high to low)</option>
+      <option value="category">Sort: Category</option>
+    </select>
+  </section>
+
+  <!-- Two-column layout: results list + detail panel -->
+  <section class="grid grid-cols-1 lg:grid-cols-5 gap-6">
+
+    <!-- LEFT: results list -->
+    <div class="lg:col-span-3">
+      <!-- x-show toggles visibility based on a boolean expression. Used here
+           for the empty state when filteredItems is empty. -->
+      <div
+        x-show="filteredItems.length === 0"
+        x-transition.opacity
+        class="rounded-lg border border-dashed border-slate-300 bg-white p-10 text-center text-slate-500"
+      >
+        Nothing matches those filters. Try clearing the search.
+      </div>
+
+      <ul x-show="filteredItems.length > 0" class="space-y-2">
+        <!-- x-for renders one element per array item. :key helps Alpine reuse
+             DOM nodes efficiently when the list changes. -->
+        <template x-for="item in filteredItems" :key="item.id">
+          <li>
+            <button
+              @click="select(item)"
+              :class="selected && selected.id === item.id
+                ? 'border-slate-900 ring-2 ring-slate-900/10'
+                : 'border-slate-200 hover:border-slate-400'"
+              class="w-full text-left bg-white border rounded-lg px-4 py-3 transition flex items-center justify-between gap-4"
+            >
+              <div class="min-w-0">
+                <!-- :class and :value are shorthand for x-bind. They evaluate
+                     a JS expression and bind it to the attribute. -->
+                <p class="font-medium truncate" x-text="item.name"></p>
+                <p class="text-sm text-slate-500">
+                  <span x-text="item.category"></span>
+                  <span class="mx-1.5 text-slate-300">·</span>
+                  <span x-text="item.tags.join(', ')"></span>
+                </p>
+              </div>
+              <span class="text-sm tabular-nums text-slate-700" x-text="money(item.price)"></span>
+            </button>
+          </li>
+        </template>
+      </ul>
+    </div>
+
+    <!-- RIGHT: detail panel for the selected item -->
+    <aside class="lg:col-span-2">
+      <!-- Empty state for the panel — shown until something is selected. -->
+      <div
+        x-show="!selected"
+        class="rounded-lg border border-slate-200 bg-white p-6 text-slate-500 text-sm"
+      >
+        Click any item on the left to see details here.
+      </div>
+
+      <!-- x-transition adds soft fade/slide animations when the element
+           enters/leaves the DOM via x-show. -->
+      <div
+        x-show="selected"
+        x-transition:enter="transition ease-out duration-200"
+        x-transition:enter-start="opacity-0 translate-y-1"
+        x-transition:enter-end="opacity-100 translate-y-0"
+        x-transition:leave="transition ease-in duration-150"
+        x-transition:leave-start="opacity-100"
+        x-transition:leave-end="opacity-0"
+        class="rounded-lg border border-slate-200 bg-white p-6"
+      >
+        <template x-if="selected">
+          <div>
+            <div class="flex items-start justify-between gap-4 mb-2">
+              <h2 class="text-xl font-semibold tracking-tight" x-text="selected.name"></h2>
+              <button
+                @click="selected = null"
+                class="text-slate-400 hover:text-slate-700 text-sm"
+                aria-label="Close"
+              >&times;</button>
+            </div>
+            <p class="text-sm text-slate-500 mb-4">
+              <span x-text="selected.category"></span>
+              <span class="mx-1.5 text-slate-300">·</span>
+              <span class="tabular-nums" x-text="money(selected.price)"></span>
+            </p>
+            <p class="text-slate-700 mb-4" x-text="selected.blurb"></p>
+            <div class="flex flex-wrap gap-1.5">
+              <template x-for="tag in selected.tags" :key="tag">
+                <span class="text-xs px-2 py-1 rounded-full bg-slate-100 text-slate-700" x-text="tag"></span>
+              </template>
+            </div>
+          </div>
+        </template>
+      </div>
+    </aside>
+  </section>
+
+  <footer class="mt-12 text-xs text-slate-400">
+    Self-contained reactive HTML — Alpine.js + Tailwind via CDN. Edit the
+    <code class="text-slate-500">items</code> array in the page source to plug in your own data.
+  </footer>
+</div>
+
+</body>
+</html>

--- a/skills/onepager/references/dashboard-with-tour.html
+++ b/skills/onepager/references/dashboard-with-tour.html
@@ -1,0 +1,560 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Revenue OS — Guided Tour Demo</title>
+
+  <!-- Tailwind via Play CDN; Alpine v3 with defer so it waits for the DOM.
+       The persist plugin loads first (defer preserves order) so $persist
+       is available inside x-data. -->
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script defer src="https://unpkg.com/@alpinejs/persist@3.14.1/dist/cdn.min.js"></script>
+  <script defer src="https://unpkg.com/alpinejs@3.14.1/dist/cdn.min.js"></script>
+
+  <style>
+    [x-cloak] { display: none !important; }
+    body { font-feature-settings: 'ss01', 'cv11'; }
+
+    /*
+      Spotlight trick: a fixed-position rectangle with a giant outset
+      box-shadow dims everything outside it. Crisper and cheaper than an
+      SVG mask, and it animates between targets just by mutating top/left
+      /width/height.
+    */
+    .spotlight {
+      position: fixed;
+      box-shadow: 0 0 0 9999px rgba(15, 23, 42, 0.72);
+      border-radius: 12px;
+      pointer-events: none;
+      transition: top 280ms ease, left 280ms ease, width 280ms ease, height 280ms ease;
+      z-index: 60;
+    }
+    .coach-card {
+      position: fixed;
+      width: 320px;
+      z-index: 70;
+      transition: top 280ms ease, left 280ms ease;
+    }
+  </style>
+</head>
+<body class="bg-slate-50 text-slate-900 antialiased">
+
+<!--
+  THE WHOLE APP LIVES IN ONE x-data BLOCK.
+  Note for editors: this attribute is HTML double-quoted, so any literal "
+  inside would close it. Strings below use apostrophes; SVG/HTML strings
+  built dynamically use template literals with single quotes inside.
+-->
+<div
+  x-cloak
+  x-data="{
+    /* --- Time range filter --- */
+    range: '30d',
+    ranges: [
+      { id: '7d',  label: '7 days' },
+      { id: '30d', label: '30 days' },
+      { id: '90d', label: '90 days' },
+      { id: 'ytd', label: 'YTD' }
+    ],
+
+    /* --- KPI snapshots per range. Pre-baked so the demo stays predictable. --- */
+    kpiData: {
+      '7d':  { revenue:  184320, dr:  4.1, mrr: 92140, dm:  1.8, churn: 1.2, dc: -0.3, arpa: 412, da: 0.8, spark: [62,68,71,73,70,76,82] },
+      '30d': { revenue:  742980, dr: 12.4, mrr: 95230, dm:  6.2, churn: 1.6, dc: -0.2, arpa: 428, da: 2.1, spark: [54,58,62,68,72,69,75,80,82,88,90,92] },
+      '90d': { revenue: 2150400, dr: 18.7, mrr: 95230, dm: 11.3, churn: 1.9, dc:  0.1, arpa: 428, da: 4.2, spark: [40,42,48,52,55,60,65,68,72,78,82,86,89,92] },
+      'ytd': { revenue: 6182550, dr: 22.4, mrr: 95230, dm: 14.1, churn: 2.1, dc:  0.4, arpa: 428, da: 7.6, spark: [30,35,42,50,58,68,75,82,86,90,92,95,98] }
+    },
+
+    /* --- Customer accounts. Mix of healthy, at-risk, churned. --- */
+    customers: [
+      { id: 1,  name: 'Northwind Logistics',  plan: 'Enterprise', mrr: 12400, status: 'healthy', stage: 'Expansion', lastSeen: '2h ago' },
+      { id: 2,  name: 'Helios Manufacturing', plan: 'Enterprise', mrr:  9800, status: 'at-risk', stage: 'Renewal',   lastSeen: '6d ago' },
+      { id: 3,  name: 'Kepler Insurance',     plan: 'Enterprise', mrr:  8400, status: 'healthy', stage: 'Live',      lastSeen: '3d ago' },
+      { id: 4,  name: 'Forge Capital',        plan: 'Pro',        mrr:  4200, status: 'healthy', stage: 'Live',      lastSeen: '1h ago' },
+      { id: 5,  name: 'Bramble & Co',         plan: 'Pro',        mrr:  3850, status: 'healthy', stage: 'Live',      lastSeen: '4h ago' },
+      { id: 6,  name: 'Tinder Logistics',     plan: 'Pro',        mrr:  3450, status: 'healthy', stage: 'Live',      lastSeen: '5h ago' },
+      { id: 7,  name: 'Cobalt Studios',       plan: 'Pro',        mrr:  3100, status: 'healthy', stage: 'Live',      lastSeen: '11m ago' },
+      { id: 8,  name: 'Dune Robotics',        plan: 'Pro',        mrr:  2800, status: 'at-risk', stage: 'Renewal',   lastSeen: '9d ago' },
+      { id: 9,  name: 'Ridge Outdoor',        plan: 'Starter',    mrr:   980, status: 'healthy', stage: 'Live',      lastSeen: '32m ago' },
+      { id: 10, name: 'Quill Media',          plan: 'Starter',    mrr:   890, status: 'churn',   stage: 'Cancelled', lastSeen: '14d ago' }
+    ],
+
+    /* --- Pipeline stages --- */
+    pipeline: [
+      { stage: 'Discovery',   count: 18, value:  480000, color: '#94a3b8' },
+      { stage: 'Pilot',       count: 12, value:  720000, color: '#60a5fa' },
+      { stage: 'Negotiation', count:  7, value: 1240000, color: '#a78bfa' },
+      { stage: 'Closed Won',  count:  4, value:  510000, color: '#34d399' }
+    ],
+
+    /* --- Table state --- */
+    search: '',
+    sortBy: 'mrr',
+    sortDir: 'desc',
+    selected: null,
+
+    /* --- Tour state ---
+       Each step targets an element via data-tour='id', with a placement
+       hint and an optional autoSelect that opens the drawer on a specific
+       customer before measuring.
+
+       tourSeen is persisted in localStorage via the @alpinejs/persist
+       plugin, so first-time visitors get the tour automatically and
+       returning visitors do not. The 'Take a tour' button always works. */
+    tour: { active: false, step: 0 },
+    tourSeen: $persist(false).as('revenue-os.tourSeen'),
+    tourSteps: [
+      { target: 'header',     title: 'Welcome to Revenue OS', body: 'Six quick stops to find your way around the dashboard. Use the buttons or the arrow keys.', placement: 'bottom' },
+      { target: 'range',      title: 'Time range',            body: 'Every metric on this page reacts to this filter. Switch periods to see how trends shift.', placement: 'bottom' },
+      { target: 'kpis',       title: 'Headline metrics',      body: 'Revenue, new MRR, churn, and ARPA. Each card shows the delta against the previous period.', placement: 'bottom' },
+      { target: 'customers',  title: 'Top accounts',          body: 'Accounts ranked by MRR. Search by name or plan, sort columns, click a row for the drawer.', placement: 'top' },
+      { target: 'customer-2', title: 'Drill into an account', body: 'Helios is at risk: 6 days quiet and sitting in renewal. Open the drawer to see the activity trail.', placement: 'top', autoSelect: 2 },
+      { target: 'drawer',     title: 'Account health',        body: 'Recent touchpoints, plan, and a one-click handoff to the assigned CSM.', placement: 'left' },
+      { target: 'pipeline',   title: 'Pipeline coverage',     body: 'Open deals by stage. Bar height encodes total value, the count badge shows how many.', placement: 'left' }
+    ],
+    bbox: null,
+
+    /* --- Computed (getters re-run when their reactive deps change) --- */
+    get current() { return this.kpiData[this.range]; },
+    get currentStep() { return this.tourSteps[this.tour.step] || null; },
+    get filtered() {
+      const q = this.search.trim().toLowerCase();
+      const dir = this.sortDir === 'asc' ? 1 : -1;
+      return this.customers
+        .filter(c => !q || c.name.toLowerCase().includes(q) || c.plan.toLowerCase().includes(q))
+        .sort((a, b) => {
+          const va = a[this.sortBy], vb = b[this.sortBy];
+          return (typeof va === 'string' ? va.localeCompare(vb) : va - vb) * dir;
+        });
+    },
+    get pipelineMax() { return Math.max(...this.pipeline.map(p => p.value)); },
+    get activity() {
+      if (!this.selected) return [];
+      const c = this.selected;
+      if (c.status === 'at-risk') return [
+        { when: c.lastSeen,  tag: 'Login',   detail: 'No active sessions in the last 6 days.' },
+        { when: '4d ago',    tag: 'Support', detail: 'Filed P2 ticket about API rate limits.' },
+        { when: '8d ago',    tag: 'Renewal', detail: 'Procurement requested a 20% discount.' },
+        { when: '21d ago',   tag: 'NPS',     detail: 'Detractor — flagged onboarding friction.' }
+      ];
+      if (c.status === 'churn') return [
+        { when: c.lastSeen,  tag: 'Cancel',  detail: 'Workspace downgraded to free tier.' },
+        { when: '18d ago',   tag: 'Email',   detail: 'CFO declined renewal quote.' },
+        { when: '34d ago',   tag: 'Support', detail: 'Escalation about export limits.' }
+      ];
+      return [
+        { when: c.lastSeen, tag: 'Login',   detail: 'Active workspace, 4 seats used today.' },
+        { when: '2d ago',   tag: 'Invoice', detail: 'Paid ' + this.money(c.mrr) + ' for ' + c.plan + ' plan.' },
+        { when: '5d ago',   tag: 'QBR',     detail: 'Quarterly review scheduled with Sam Patel.' },
+        { when: '12d ago',  tag: 'Feature', detail: 'Enabled SSO and audit log exports.' }
+      ];
+    },
+
+    /* --- Format helpers --- */
+    money(n)      { return '$' + n.toLocaleString(); },
+    moneyShort(n) {
+      if (n >= 1e6) return '$' + (n/1e6).toFixed(2) + 'M';
+      if (n >= 1e3) return '$' + (n/1e3).toFixed(1) + 'k';
+      return '$' + n;
+    },
+    pct(n)        { return (n > 0 ? '+' : '') + n.toFixed(1) + '%'; },
+    sparkPoints(arr) {
+      if (!arr || !arr.length) return '';
+      const max = Math.max(...arr), min = Math.min(...arr), span = max - min || 1;
+      return arr.map((v, i) =>
+        (i / (arr.length - 1) * 100).toFixed(2) + ',' + (28 - (v - min) / span * 26).toFixed(2)
+      ).join(' ');
+    },
+    statusClass(s) {
+      return s === 'healthy' ? 'bg-emerald-100 text-emerald-700'
+           : s === 'at-risk' ? 'bg-amber-100 text-amber-700'
+                             : 'bg-rose-100 text-rose-700';
+    },
+    sortToggle(col) {
+      if (this.sortBy === col) {
+        this.sortDir = this.sortDir === 'asc' ? 'desc' : 'asc';
+      } else {
+        this.sortBy = col;
+        this.sortDir = col === 'name' ? 'asc' : 'desc';
+      }
+    },
+
+    /* --- Tour controls --- */
+    startTour() { this.tour.active = true; this.tour.step = 0; this.applyStep(); },
+    endTour()   { this.tour.active = false; this.bbox = null; this.tourSeen = true; },
+    resetTour() { this.tourSeen = false; this.startTour(); },
+    nextStep()  {
+      if (this.tour.step >= this.tourSteps.length - 1) return this.endTour();
+      this.tour.step++; this.applyStep();
+    },
+    prevStep()  { if (this.tour.step > 0) { this.tour.step--; this.applyStep(); } },
+    applyStep() {
+      const s = this.currentStep;
+      if (!s) return;
+      if (s.autoSelect != null) {
+        this.selected = this.customers.find(c => c.id === s.autoSelect) || null;
+      }
+      this.$nextTick(() => this.measureTarget());
+    },
+    measureTarget() {
+      const s = this.currentStep;
+      if (!s) { this.bbox = null; return; }
+      const el = document.querySelector('[data-tour=' + s.target + ']');
+      if (!el) { this.bbox = null; return; }
+      el.scrollIntoView({ block: 'center', behavior: 'smooth' });
+      requestAnimationFrame(() => {
+        const r = el.getBoundingClientRect();
+        this.bbox = { top: r.top, left: r.left, width: r.width, height: r.height };
+      });
+    },
+    get spotlightStyle() {
+      if (!this.bbox) return 'display:none';
+      const pad = 8;
+      return 'top:' + (this.bbox.top - pad) + 'px;' +
+             'left:' + (this.bbox.left - pad) + 'px;' +
+             'width:' + (this.bbox.width + pad*2) + 'px;' +
+             'height:' + (this.bbox.height + pad*2) + 'px;';
+    },
+    get tooltipStyle() {
+      if (!this.bbox || !this.currentStep) return 'display:none';
+      const m = 18, b = this.bbox, p = this.currentStep.placement;
+      if (p === 'top')   return 'top:' + (b.top - m) + 'px;left:' + (b.left + b.width/2) + 'px;transform:translate(-50%,-100%);';
+      if (p === 'left')  return 'top:' + (b.top + b.height/2) + 'px;left:' + (b.left - m) + 'px;transform:translate(-100%,-50%);';
+      if (p === 'right') return 'top:' + (b.top + b.height/2) + 'px;left:' + (b.left + b.width + m) + 'px;transform:translate(0,-50%);';
+      return                 'top:' + (b.top + b.height + m) + 'px;left:' + (b.left + b.width/2) + 'px;transform:translate(-50%,0);';
+    },
+
+    /* Re-measure on scroll/resize so the spotlight tracks its target. */
+    init() {
+      const remeasure = () => { if (this.tour.active) this.measureTarget(); };
+      window.addEventListener('resize', remeasure);
+      window.addEventListener('scroll', remeasure, { passive: true });
+      window.addEventListener('keydown', (e) => {
+        if (!this.tour.active) return;
+        if (e.key === 'Escape')       this.endTour();
+        if (e.key === 'ArrowRight')   this.nextStep();
+        if (e.key === 'ArrowLeft')    this.prevStep();
+        if (e.key === 'Enter')        this.nextStep();
+      });
+      /* First-time visitors get the tour automatically, after a short pause
+         so the layout settles. Returning visitors land on the dashboard
+         directly and can replay the tour from the button if they want. */
+      if (!this.tourSeen) setTimeout(() => this.startTour(), 600);
+    }
+  }"
+  class="mx-auto max-w-7xl px-6 py-8"
+>
+
+  <!-- HEADER -->
+  <header data-tour="header" class="flex items-center justify-between gap-4 flex-wrap mb-6">
+    <div class="flex items-center gap-3">
+      <div class="w-9 h-9 rounded-lg bg-slate-900 text-white grid place-items-center font-semibold">R</div>
+      <div>
+        <h1 class="text-xl font-semibold tracking-tight">Revenue OS</h1>
+        <p class="text-sm text-slate-500">Welcome back — here's how the book is doing.</p>
+      </div>
+    </div>
+
+    <div class="flex items-center gap-3">
+      <!-- Time range pills. Each pill toggles `range`. -->
+      <div data-tour="range" class="inline-flex bg-white rounded-md border border-slate-300 p-1 text-sm">
+        <template x-for="r in ranges" :key="r.id">
+          <button
+            @click="range = r.id"
+            :class="range === r.id ? 'bg-slate-900 text-white' : 'text-slate-600 hover:bg-slate-100'"
+            class="px-3 py-1 rounded transition"
+            x-text="r.label"
+          ></button>
+        </template>
+      </div>
+      <button
+        data-tour="tour-button"
+        @click="startTour()"
+        class="text-sm px-3 py-2 rounded-md bg-slate-900 text-white hover:bg-slate-800 transition"
+        x-text="tourSeen ? 'Replay tour' : 'Take a tour'"
+      ></button>
+    </div>
+  </header>
+
+  <!-- KPI STRIP -->
+  <section data-tour="kpis" class="grid grid-cols-2 lg:grid-cols-4 gap-4 mb-8">
+    <!-- Revenue -->
+    <div class="bg-white rounded-lg border border-slate-200 p-4">
+      <p class="text-xs uppercase tracking-wide text-slate-500">Revenue</p>
+      <p class="text-2xl font-semibold tabular-nums mt-1" x-text="moneyShort(current.revenue)"></p>
+      <p class="text-xs mt-1" :class="current.dr >= 0 ? 'text-emerald-600' : 'text-rose-600'">
+        <span x-text="pct(current.dr)"></span>
+        <span class="text-slate-400">vs prior period</span>
+      </p>
+      <svg viewBox="0 0 100 30" class="w-full h-8 mt-3 text-emerald-500" preserveAspectRatio="none">
+        <polyline :points="sparkPoints(current.spark)" fill="none" stroke="currentColor" stroke-width="1.5"/>
+      </svg>
+    </div>
+
+    <!-- New MRR -->
+    <div class="bg-white rounded-lg border border-slate-200 p-4">
+      <p class="text-xs uppercase tracking-wide text-slate-500">New MRR</p>
+      <p class="text-2xl font-semibold tabular-nums mt-1" x-text="moneyShort(current.mrr)"></p>
+      <p class="text-xs mt-1" :class="current.dm >= 0 ? 'text-emerald-600' : 'text-rose-600'">
+        <span x-text="pct(current.dm)"></span>
+        <span class="text-slate-400">vs prior period</span>
+      </p>
+      <div class="mt-3 flex items-end gap-1 h-8">
+        <template x-for="(v, i) in current.spark" :key="i">
+          <div class="flex-1 bg-blue-200 rounded-sm" :style="'height:' + (v/100 * 100) + '%'"></div>
+        </template>
+      </div>
+    </div>
+
+    <!-- Churn -->
+    <div class="bg-white rounded-lg border border-slate-200 p-4">
+      <p class="text-xs uppercase tracking-wide text-slate-500">Net churn</p>
+      <p class="text-2xl font-semibold tabular-nums mt-1" x-text="current.churn.toFixed(1) + '%'"></p>
+      <p class="text-xs mt-1" :class="current.dc <= 0 ? 'text-emerald-600' : 'text-rose-600'">
+        <span x-text="pct(current.dc)"></span>
+        <span class="text-slate-400">vs prior period</span>
+      </p>
+      <p class="mt-4 text-xs text-slate-500">Lower is better. Targeting under 2.0%.</p>
+    </div>
+
+    <!-- ARPA -->
+    <div class="bg-white rounded-lg border border-slate-200 p-4">
+      <p class="text-xs uppercase tracking-wide text-slate-500">ARPA</p>
+      <p class="text-2xl font-semibold tabular-nums mt-1" x-text="money(current.arpa)"></p>
+      <p class="text-xs mt-1" :class="current.da >= 0 ? 'text-emerald-600' : 'text-rose-600'">
+        <span x-text="pct(current.da)"></span>
+        <span class="text-slate-400">vs prior period</span>
+      </p>
+      <p class="mt-4 text-xs text-slate-500">Average revenue per account, all plans.</p>
+    </div>
+  </section>
+
+  <!-- MAIN GRID -->
+  <section class="grid grid-cols-1 lg:grid-cols-5 gap-6">
+
+    <!-- LEFT: customer table -->
+    <div data-tour="customers" class="lg:col-span-3 bg-white rounded-lg border border-slate-200">
+      <div class="p-4 flex items-center justify-between gap-3 border-b border-slate-200">
+        <div>
+          <h2 class="font-semibold tracking-tight">Top accounts</h2>
+          <p class="text-xs text-slate-500" x-text="filtered.length + ' of ' + customers.length + ' shown'"></p>
+        </div>
+        <input
+          type="search"
+          x-model="search"
+          placeholder="Search name or plan…"
+          class="text-sm rounded-md border border-slate-300 px-3 py-1.5 focus:outline-none focus:ring-2 focus:ring-slate-900/10"
+        >
+      </div>
+
+      <table class="w-full text-sm">
+        <thead class="text-xs uppercase text-slate-500 bg-slate-50">
+          <tr>
+            <th class="text-left px-4 py-2 font-medium cursor-pointer" @click="sortToggle('name')">
+              Account
+              <span x-show="sortBy === 'name'" x-text="sortDir === 'asc' ? '↑' : '↓'"></span>
+            </th>
+            <th class="text-left px-4 py-2 font-medium">Plan</th>
+            <th class="text-right px-4 py-2 font-medium cursor-pointer" @click="sortToggle('mrr')">
+              MRR
+              <span x-show="sortBy === 'mrr'" x-text="sortDir === 'asc' ? '↑' : '↓'"></span>
+            </th>
+            <th class="text-left px-4 py-2 font-medium">Status</th>
+            <th class="text-left px-4 py-2 font-medium hidden md:table-cell">Last seen</th>
+          </tr>
+        </thead>
+        <tbody>
+          <template x-for="c in filtered" :key="c.id">
+            <tr
+              :data-tour="'customer-' + c.id"
+              @click="selected = c"
+              :class="selected && selected.id === c.id ? 'bg-slate-50' : 'hover:bg-slate-50'"
+              class="border-t border-slate-100 cursor-pointer"
+            >
+              <td class="px-4 py-3 font-medium" x-text="c.name"></td>
+              <td class="px-4 py-3 text-slate-600" x-text="c.plan"></td>
+              <td class="px-4 py-3 text-right tabular-nums" x-text="money(c.mrr)"></td>
+              <td class="px-4 py-3">
+                <span class="text-xs px-2 py-0.5 rounded-full" :class="statusClass(c.status)" x-text="c.status"></span>
+              </td>
+              <td class="px-4 py-3 text-slate-500 hidden md:table-cell" x-text="c.lastSeen"></td>
+            </tr>
+          </template>
+          <tr x-show="filtered.length === 0">
+            <td colspan="5" class="px-4 py-10 text-center text-slate-500">No accounts match that filter.</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <!-- RIGHT: pipeline -->
+    <aside data-tour="pipeline" class="lg:col-span-2 bg-white rounded-lg border border-slate-200 p-4">
+      <div class="flex items-baseline justify-between mb-3">
+        <h2 class="font-semibold tracking-tight">Pipeline</h2>
+        <span class="text-xs text-slate-500 tabular-nums" x-text="pipeline.reduce((s,p) => s + p.count, 0) + ' open'"></span>
+      </div>
+      <ul class="space-y-3">
+        <template x-for="p in pipeline" :key="p.stage">
+          <li>
+            <div class="flex items-baseline justify-between text-sm mb-1">
+              <span class="font-medium" x-text="p.stage"></span>
+              <span class="tabular-nums text-slate-700" x-text="moneyShort(p.value)"></span>
+            </div>
+            <div class="h-2 rounded-full bg-slate-100 overflow-hidden">
+              <div
+                class="h-full rounded-full"
+                :style="'width:' + (p.value / pipelineMax * 100) + '%; background-color:' + p.color"
+              ></div>
+            </div>
+            <p class="text-xs text-slate-500 mt-1" x-text="p.count + ' deals'"></p>
+          </li>
+        </template>
+      </ul>
+      <div class="mt-5 pt-4 border-t border-slate-100 text-xs text-slate-500">
+        Forecast coverage: <span class="font-medium text-slate-700 tabular-nums">3.2× quota</span>
+      </div>
+    </aside>
+  </section>
+
+  <!-- DRAWER (slides in from the right when an account is selected) -->
+  <div
+    x-show="selected"
+    @click.self="selected = null"
+    x-transition.opacity
+    class="fixed inset-0 bg-slate-900/30 z-40"
+  ></div>
+  <aside
+    data-tour="drawer"
+    x-show="selected"
+    x-transition:enter="transition ease-out duration-300"
+    x-transition:enter-start="translate-x-full"
+    x-transition:enter-end="translate-x-0"
+    x-transition:leave="transition ease-in duration-200"
+    x-transition:leave-start="translate-x-0"
+    x-transition:leave-end="translate-x-full"
+    class="fixed top-0 right-0 h-full w-full sm:w-[420px] bg-white z-50 border-l border-slate-200 overflow-y-auto"
+  >
+    <template x-if="selected">
+      <div class="p-6">
+        <div class="flex items-start justify-between mb-4">
+          <div class="flex items-center gap-3">
+            <div class="w-10 h-10 rounded-lg bg-slate-900 text-white grid place-items-center font-semibold"
+                 x-text="selected.name.split(' ').map(w => w[0]).join('').slice(0,2)"></div>
+            <div>
+              <h3 class="font-semibold tracking-tight" x-text="selected.name"></h3>
+              <p class="text-sm text-slate-500">
+                <span x-text="selected.plan"></span>
+                <span class="mx-1.5 text-slate-300">·</span>
+                <span x-text="selected.stage"></span>
+              </p>
+            </div>
+          </div>
+          <button @click="selected = null" class="text-slate-400 hover:text-slate-700" aria-label="Close">&times;</button>
+        </div>
+
+        <div class="grid grid-cols-3 gap-3 mb-5">
+          <div class="bg-slate-50 rounded-md p-3">
+            <p class="text-xs text-slate-500">MRR</p>
+            <p class="font-semibold tabular-nums" x-text="money(selected.mrr)"></p>
+          </div>
+          <div class="bg-slate-50 rounded-md p-3">
+            <p class="text-xs text-slate-500">Status</p>
+            <p class="font-semibold capitalize" x-text="selected.status"></p>
+          </div>
+          <div class="bg-slate-50 rounded-md p-3">
+            <p class="text-xs text-slate-500">Last seen</p>
+            <p class="font-semibold" x-text="selected.lastSeen"></p>
+          </div>
+        </div>
+
+        <h4 class="text-xs uppercase tracking-wide text-slate-500 mb-2">Recent activity</h4>
+        <ol class="space-y-3 mb-5">
+          <template x-for="(a, i) in activity" :key="i">
+            <li class="flex gap-3">
+              <div class="w-1.5 mt-1.5 h-1.5 rounded-full bg-slate-400 shrink-0"></div>
+              <div class="min-w-0 flex-1">
+                <div class="flex items-baseline justify-between gap-2">
+                  <span class="text-xs font-medium uppercase tracking-wide text-slate-500" x-text="a.tag"></span>
+                  <span class="text-xs text-slate-400" x-text="a.when"></span>
+                </div>
+                <p class="text-sm text-slate-700" x-text="a.detail"></p>
+              </div>
+            </li>
+          </template>
+        </ol>
+
+        <div class="flex gap-2">
+          <button class="flex-1 text-sm px-3 py-2 rounded-md bg-slate-900 text-white hover:bg-slate-800 transition">
+            Open in CRM
+          </button>
+          <button class="flex-1 text-sm px-3 py-2 rounded-md border border-slate-300 hover:bg-slate-100 transition">
+            Schedule QBR
+          </button>
+        </div>
+      </div>
+    </template>
+  </aside>
+
+  <footer class="mt-10 text-xs text-slate-400">
+    Self-contained Alpine.js + Tailwind demo. The tour overlay is one
+    fixed-position spotlight plus a coaching card; both reposition by
+    measuring <code class="text-slate-500">getBoundingClientRect</code> on
+    the active step's <code class="text-slate-500">data-tour</code> target.
+  </footer>
+
+  <!-- COACHING-MARK OVERLAY -->
+  <!-- Spotlight: dims the page everywhere except the target rectangle. -->
+  <div class="spotlight" x-show="tour.active && bbox" :style="spotlightStyle"></div>
+
+  <!-- Click trap: catches clicks outside the spotlight while the tour is on
+       so the underlying UI doesn't react. The spotlight has pointer-events
+       none, so this trap fills the rest of the viewport. -->
+  <div
+    x-show="tour.active"
+    x-transition.opacity
+    @click="endTour()"
+    class="fixed inset-0 z-50"
+    style="background: transparent"
+  ></div>
+
+  <!-- Coaching card: title, body, controls, step counter. -->
+  <div
+    x-show="tour.active && bbox"
+    x-transition:enter="transition ease-out duration-200"
+    x-transition:enter-start="opacity-0 scale-95"
+    x-transition:enter-end="opacity-100 scale-100"
+    @click.stop
+    class="coach-card bg-white rounded-lg shadow-2xl border border-slate-200 p-5"
+    :style="tooltipStyle"
+  >
+    <template x-if="currentStep">
+      <div>
+        <div class="flex items-center justify-between mb-2">
+          <span class="text-xs font-medium uppercase tracking-wide text-slate-500"
+                x-text="(tour.step + 1) + ' / ' + tourSteps.length"></span>
+          <button @click="endTour()" class="text-slate-400 hover:text-slate-700 text-sm" aria-label="Skip tour">Skip</button>
+        </div>
+        <h3 class="font-semibold tracking-tight text-slate-900 mb-1" x-text="currentStep.title"></h3>
+        <p class="text-sm text-slate-600 mb-4" x-text="currentStep.body"></p>
+        <div class="flex items-center justify-between gap-2">
+          <button
+            @click="prevStep()"
+            :disabled="tour.step === 0"
+            :class="tour.step === 0 ? 'opacity-40 cursor-not-allowed' : 'hover:bg-slate-100'"
+            class="text-sm px-3 py-1.5 rounded-md border border-slate-300 transition"
+          >Back</button>
+          <button
+            @click="nextStep()"
+            class="text-sm px-3 py-1.5 rounded-md bg-slate-900 text-white hover:bg-slate-800 transition"
+            x-text="tour.step === tourSteps.length - 1 ? 'Done' : 'Next'"
+          ></button>
+        </div>
+      </div>
+    </template>
+  </div>
+
+</div>
+
+</body>
+</html>

--- a/skills/onepager/references/slide-deck.html
+++ b/skills/onepager/references/slide-deck.html
@@ -1,0 +1,303 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Q1 Business Review — Slide Deck</title>
+
+  <!-- Tailwind via Play CDN; Alpine v3 with defer. -->
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script defer src="https://unpkg.com/alpinejs@3.14.1/dist/cdn.min.js"></script>
+
+  <style>
+    [x-cloak] { display: none !important; }
+    body { font-feature-settings: 'ss01', 'cv11'; }
+    /* Fixed-aspect slide stage so things look the same across screen sizes. */
+    .stage {
+      width: min(96vw, 1280px);
+      aspect-ratio: 16 / 10;
+      max-height: 88vh;
+    }
+    /* Subtle entrance animation between slides. */
+    @keyframes slide-in { from { opacity: 0; transform: translateY(8px) } to { opacity: 1; transform: none } }
+    .slide-anim { animation: slide-in 280ms ease both; }
+  </style>
+</head>
+<body class="bg-slate-100 text-slate-900 antialiased">
+
+<!--
+  Slide-deck pattern from the onepager skill.
+  - One slide visible at a time, indexed by `slide`.
+  - Arrow keys / Space advance, ←/Backspace retreat, Home/End jump.
+  - `n` toggles speaker notes, `f` toggles a fullscreen mode that hides chrome.
+  - All slides live in the `slides` array; render branches on slide.type.
+-->
+<div
+  x-cloak
+  x-data="{
+    slide: 0,
+    fullscreen: false,
+    showNotes: false,
+
+    slides: [
+      {
+        type: 'cover',
+        eyebrow: 'Q1 Business Review',
+        title: 'Revenue OS',
+        subtitle: 'Where the book is, where it is going, and the calls we need',
+        meta: 'May 2026 · Prepared for the leadership team',
+        notes: 'Set context: this is the first deep-dive of the year. Keep it 25 minutes plus questions. Tomás and Priya are dialled in for the Helios slide.'
+      },
+      {
+        type: 'bullets',
+        eyebrow: 'Section one',
+        title: 'Headline numbers',
+        bullets: [
+          'Revenue $743k for the period — up 12.4% on Q4',
+          'Net new MRR $95.2k — second-best quarter on record',
+          'Net churn held at 1.6% (target was 2.0%)',
+          'ARPA up to $428, lifted by two enterprise expansions'
+        ],
+        notes: 'Lead with the wins, but flag that ARPA growth is concentrated in 2 accounts. If either churns the headline falls 4 points.'
+      },
+      {
+        type: 'metric',
+        eyebrow: 'Detail',
+        title: 'Where the growth came from',
+        metrics: [
+          { label: 'Net new logos',      value: '14', delta: '+3 vs Q4' },
+          { label: 'Expansion revenue',  value: '$58k', delta: 'Northwind +1 tier, Kepler +12 seats' },
+          { label: 'Reactivations',      value: '2',  delta: 'Forge, Bramble' },
+          { label: 'Avg deal size',      value: '$5.4k', delta: 'up 9%' }
+        ],
+        notes: 'Reactivations are a leading indicator — both came from the win-back campaign. Keep that programme funded.'
+      },
+      {
+        type: 'bullets',
+        eyebrow: 'Where we lost ground',
+        title: 'What did not work',
+        bullets: [
+          'Quill Media churned voluntarily — declined save call',
+          'Helios renewal at risk: 6 days quiet, procurement asking for 20% off',
+          'Two API outages drove the bulk of CSAT dips in March',
+          'Self-serve activation flat — investment in onboarding has not landed yet'
+        ],
+        notes: 'Do not gloss the API outages. Reliability is the renewal blocker for Northwind too. If we get one more in Q2 we should expect concession asks.'
+      },
+      {
+        type: 'quote',
+        eyebrow: 'Customer story',
+        attribution: 'Tomás Riveira · Helios Manufacturing',
+        quote: 'We are open to a multi-year deal if that helps. Send me a counter-proposal before Friday.',
+        body: 'Helios is the largest at-risk renewal in the book. AE has the counter; meeting Friday morning. We are modelling a flat two-year extension or a three-year deal with the price step deferred to year three.',
+        notes: 'Decision needed today: do we authorise the flat two-year? It is a $14k impact vs list price.'
+      },
+      {
+        type: 'code',
+        eyebrow: 'How we are tracking it',
+        title: 'New: account-health signal in the dashboard',
+        body: 'Mixes session activity, ticket sentiment, and renewal stage into a single score. Live in Revenue OS for two weeks.',
+        code: 'const health = (account) => {\n  const dormant  = daysSinceLogin(account) > 5 ? 1 : 0;\n  const tickets  = recentNegativeTickets(account, 30);\n  const renewing = renewalDaysOut(account) < 30 ? 1 : 0;\n  return clamp(100 - dormant*15 - tickets*10 - renewing*10, 0, 100);\n};',
+        notes: 'Already flagged Helios and Dune Robotics before either showed up in NPS. Do not over-rotate — the score is a prompt for a CSM call, not a verdict.'
+      },
+      {
+        type: 'bullets',
+        eyebrow: 'Looking forward',
+        title: 'Q2 priorities',
+        bullets: [
+          'Reliability: ship the rate-limit overhaul before the Northwind renewal',
+          'Helios: close the renewal at flat pricing, multi-year structure',
+          'Onboarding: rebuild the activation flow with coaching marks',
+          'Pricing: validate the new Business tier with three pilot accounts'
+        ],
+        notes: 'Each priority has a named owner and a Friday-of-each-week check-in slot. Pricing pilot list is in the appendix.'
+      },
+      {
+        type: 'cover',
+        eyebrow: 'Decisions needed',
+        title: 'Three asks before we leave the room',
+        subtitle: '1. Approve flat-pricing on Helios renewal.  2. Sign off on rate-limit overhaul scope.  3. Pick the three Business-tier pilots.',
+        meta: 'Thank you. Notes and recording in the shared drive after the call.',
+        notes: 'Hold the room until all three are decided. Do not let this slide into a follow-up email.'
+      }
+    ],
+
+    /* --- Computed --- */
+    get current() { return this.slides[this.slide]; },
+    get progress() { return ((this.slide + 1) / this.slides.length) * 100; },
+
+    /* --- Methods --- */
+    next()  { if (this.slide < this.slides.length - 1) this.slide++; },
+    prev()  { if (this.slide > 0) this.slide--; },
+    first() { this.slide = 0; },
+    last()  { this.slide = this.slides.length - 1; },
+
+    init() {
+      window.addEventListener('keydown', (e) => {
+        if (e.key === 'ArrowRight' || e.key === ' ') { this.next(); e.preventDefault(); }
+        if (e.key === 'ArrowLeft' || e.key === 'Backspace') { this.prev(); e.preventDefault(); }
+        if (e.key === 'Home') this.first();
+        if (e.key === 'End')  this.last();
+        if (e.key === 'n' || e.key === 'N') this.showNotes = !this.showNotes;
+        if (e.key === 'f' || e.key === 'F') this.fullscreen = !this.fullscreen;
+        if (e.key === 'Escape') { this.fullscreen = false; this.showNotes = false; }
+      });
+    }
+  }"
+  class="min-h-screen flex flex-col items-center"
+>
+
+  <!-- Progress bar pinned to the top of the viewport. -->
+  <div class="w-full h-1 bg-slate-200">
+    <div class="h-full bg-slate-900 transition-all duration-300" :style="'width:' + progress + '%'"></div>
+  </div>
+
+  <!-- Top chrome — hidden when fullscreen is on. -->
+  <header
+    x-show="!fullscreen"
+    x-transition.opacity
+    class="w-full max-w-7xl px-6 py-4 flex items-center justify-between"
+  >
+    <div class="flex items-center gap-3 text-sm text-slate-500">
+      <span class="w-2 h-2 rounded-full bg-slate-400"></span>
+      <span>Q1 Business Review</span>
+    </div>
+    <div class="flex items-center gap-2 text-xs text-slate-500">
+      <span>Press <kbd class="px-1.5 py-0.5 rounded bg-slate-200 text-slate-700">→</kbd> to advance</span>
+      <span class="text-slate-300">·</span>
+      <span><kbd class="px-1.5 py-0.5 rounded bg-slate-200 text-slate-700">n</kbd> notes</span>
+      <span class="text-slate-300">·</span>
+      <span><kbd class="px-1.5 py-0.5 rounded bg-slate-200 text-slate-700">f</kbd> hide chrome</span>
+    </div>
+  </header>
+
+  <!-- The slide stage. We re-mount the inner content when slide changes
+       (using :key on a wrapper) so the entrance animation runs each time. -->
+  <main class="flex-1 w-full flex items-center justify-center px-6 pb-6">
+    <div class="stage bg-white rounded-2xl border border-slate-200 shadow-sm overflow-hidden flex">
+      <template :key="slide" x-if="current">
+        <div class="slide-anim flex-1 flex flex-col justify-center px-12 py-10">
+
+          <!-- Cover layout -->
+          <template x-if="current.type === 'cover'">
+            <div>
+              <p class="text-xs uppercase tracking-[0.2em] text-slate-500 mb-3" x-text="current.eyebrow"></p>
+              <h2 class="text-5xl font-semibold tracking-tight mb-4" x-text="current.title"></h2>
+              <p class="text-xl text-slate-700 mb-12 max-w-3xl leading-snug" x-text="current.subtitle"></p>
+              <p class="text-sm text-slate-500" x-text="current.meta"></p>
+            </div>
+          </template>
+
+          <!-- Bullets layout -->
+          <template x-if="current.type === 'bullets'">
+            <div>
+              <p class="text-xs uppercase tracking-[0.2em] text-slate-500 mb-2" x-text="current.eyebrow"></p>
+              <h2 class="text-4xl font-semibold tracking-tight mb-8" x-text="current.title"></h2>
+              <ul class="space-y-3 max-w-3xl">
+                <template x-for="(b, i) in current.bullets" :key="i">
+                  <li class="flex gap-3 text-lg text-slate-800 leading-relaxed">
+                    <span class="text-slate-400 tabular-nums" x-text="(i + 1).toString().padStart(2, '0')"></span>
+                    <span x-text="b"></span>
+                  </li>
+                </template>
+              </ul>
+            </div>
+          </template>
+
+          <!-- Metric layout -->
+          <template x-if="current.type === 'metric'">
+            <div>
+              <p class="text-xs uppercase tracking-[0.2em] text-slate-500 mb-2" x-text="current.eyebrow"></p>
+              <h2 class="text-4xl font-semibold tracking-tight mb-10" x-text="current.title"></h2>
+              <div class="grid grid-cols-2 gap-6 max-w-3xl">
+                <template x-for="m in current.metrics" :key="m.label">
+                  <div>
+                    <p class="text-xs uppercase tracking-wide text-slate-500 mb-1" x-text="m.label"></p>
+                    <p class="text-3xl font-semibold tabular-nums" x-text="m.value"></p>
+                    <p class="text-sm text-slate-600 mt-1" x-text="m.delta"></p>
+                  </div>
+                </template>
+              </div>
+            </div>
+          </template>
+
+          <!-- Quote layout -->
+          <template x-if="current.type === 'quote'">
+            <div>
+              <p class="text-xs uppercase tracking-[0.2em] text-slate-500 mb-3" x-text="current.eyebrow"></p>
+              <blockquote class="text-3xl font-medium tracking-tight leading-snug mb-6 max-w-3xl">
+                <span class="text-slate-300">“</span><span x-text="current.quote"></span><span class="text-slate-300">”</span>
+              </blockquote>
+              <p class="text-sm text-slate-500 mb-6" x-text="'— ' + current.attribution"></p>
+              <p class="text-base text-slate-700 max-w-2xl leading-relaxed" x-text="current.body"></p>
+            </div>
+          </template>
+
+          <!-- Code layout -->
+          <template x-if="current.type === 'code'">
+            <div>
+              <p class="text-xs uppercase tracking-[0.2em] text-slate-500 mb-2" x-text="current.eyebrow"></p>
+              <h2 class="text-3xl font-semibold tracking-tight mb-4" x-text="current.title"></h2>
+              <p class="text-base text-slate-700 mb-6 max-w-3xl" x-text="current.body"></p>
+              <pre class="bg-slate-900 text-slate-100 rounded-lg p-5 text-sm leading-relaxed overflow-x-auto"><code x-text="current.code"></code></pre>
+            </div>
+          </template>
+        </div>
+      </template>
+    </div>
+  </main>
+
+  <!-- Bottom chrome: counter, prev/next, hide-chrome hint. -->
+  <footer
+    x-show="!fullscreen"
+    x-transition.opacity
+    class="w-full max-w-7xl px-6 pb-6 flex items-center justify-between"
+  >
+    <div class="text-sm text-slate-500 tabular-nums">
+      <span x-text="slide + 1"></span>
+      <span class="text-slate-300 mx-1">/</span>
+      <span x-text="slides.length"></span>
+    </div>
+    <div class="flex items-center gap-2">
+      <button
+        @click="prev()"
+        :disabled="slide === 0"
+        :class="slide === 0 ? 'opacity-40 cursor-not-allowed' : 'hover:bg-slate-100'"
+        class="text-sm px-3 py-1.5 rounded-md border border-slate-300 bg-white transition"
+      >Back</button>
+      <button
+        @click="next()"
+        :disabled="slide === slides.length - 1"
+        :class="slide === slides.length - 1 ? 'opacity-40 cursor-not-allowed' : 'hover:bg-slate-800'"
+        class="text-sm px-3 py-1.5 rounded-md bg-slate-900 text-white transition"
+      >Next</button>
+    </div>
+  </footer>
+
+  <!-- Speaker notes drawer. Toggled with `n`. -->
+  <aside
+    x-show="showNotes"
+    @click.self="showNotes = false"
+    x-transition.opacity
+    class="fixed inset-x-0 bottom-0 bg-slate-900/95 text-slate-100 px-8 py-6 z-50 backdrop-blur"
+  >
+    <div class="max-w-4xl mx-auto">
+      <div class="flex items-center justify-between mb-2">
+        <p class="text-xs uppercase tracking-[0.2em] text-slate-400">Speaker notes</p>
+        <button @click="showNotes = false" class="text-slate-400 hover:text-slate-100 text-sm">close</button>
+      </div>
+      <p class="text-base leading-relaxed" x-text="current.notes"></p>
+    </div>
+  </aside>
+
+  <!-- Subtle reminder of the fullscreen toggle while it's on. -->
+  <div
+    x-show="fullscreen"
+    x-transition.opacity.duration.500ms
+    class="fixed bottom-4 right-4 text-[11px] text-slate-400"
+  >press <kbd class="px-1 py-0.5 rounded bg-slate-200 text-slate-700">f</kbd> to show chrome</div>
+
+</div>
+
+</body>
+</html>

--- a/skills/onepager/references/streaming-ai.html
+++ b/skills/onepager/references/streaming-ai.html
@@ -1,0 +1,504 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Inbox Copilot — Simulated AI Triage</title>
+
+  <!-- Tailwind via Play CDN; Alpine v3 with defer. -->
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script defer src="https://unpkg.com/alpinejs@3.14.1/dist/cdn.min.js"></script>
+
+  <style>
+    [x-cloak] { display: none !important; }
+    body { font-feature-settings: 'ss01', 'cv11'; }
+
+    /* Blinking cursor at the end of the streaming reply. */
+    @keyframes blink { 0%, 49% { opacity: 1 } 50%, 100% { opacity: 0 } }
+    .caret { display: inline-block; width: 6px; height: 1em; vertical-align: -2px;
+             background: currentColor; margin-left: 2px; animation: blink 900ms steps(2) infinite; }
+
+    /* Soft entrance for thinking-step rows. */
+    @keyframes pop-in { from { opacity: 0; transform: translateY(2px) } to { opacity: 1; transform: none } }
+    .pop-in { animation: pop-in 220ms ease both; }
+  </style>
+</head>
+<body class="bg-slate-50 text-slate-900 antialiased">
+
+<!--
+  THE WHOLE APP LIVES IN ONE x-data BLOCK.
+  Important: this attribute is HTML double-quoted, so any literal " inside
+  would close it. All strings below use apostrophes; template literals use
+  apostrophes for embedded HTML/SVG attribute values.
+
+  The AI is fully simulated. Each ticket carries pre-written 'thinking' steps
+  and two candidate replies. runAI() walks the steps with setTimeout, then
+  streams the reply word-by-word. A monotonic runId aborts stale runs when
+  the user jumps between tickets mid-stream.
+-->
+<div
+  x-cloak
+  x-data="{
+    /* --- Inbox: same customer base as the revenue dashboard. --- */
+    tickets: [
+      {
+        id: 1,
+        sender: 'Maya Chen', email: 'maya@northwind.com',
+        company: 'Northwind Logistics', plan: 'Enterprise',
+        channel: 'Email', received: '12 min ago',
+        subject: 'API rate limits hit during overnight batch',
+        body: 'Hey team — our overnight ETL kept hitting your 429 limit around 02:00 UTC, twice on /v2/orders. We had to retry the whole job by hand at 04:30. Renewal is 24th of next month and procurement is asking if this is going to keep happening. Can you look at the request pattern from our side?\n\n— Maya',
+        ai: {
+          category: 'Technical · API limits',
+          priority: 'High', sentiment: 'frustrated', confidence: 92,
+          history: [
+            'Enterprise tenure: 18 months',
+            'Two related tickets in the last 30 days',
+            'Renewal in 47 days, $12,400 MRR'
+          ],
+          thinking: [
+            'Parsing message intent and extracting timestamps…',
+            'Looking up account: Northwind Logistics',
+            'Checking ticket history (2 prior API-related)',
+            'Cross-referencing API logs at 02:00 UTC',
+            'Drafting reply…'
+          ],
+          replies: [
+            'Hi Maya — sorry for the friction. I confirmed two 429 bursts overnight at 02:01 and 02:14 UTC, both on /v2/orders. Your Enterprise tier currently allows 1,200 req/min and the bursts peaked at 1,580. I have lifted the ceiling to 2,000 req/min for the next 14 days while we look at adding burst credits to your contract. The renewal call on the 24th would be a good time to formalise this — happy to loop in your AE.',
+            'Hi Maya — thanks for flagging this. The 429s line up with what we are seeing in our metrics: two short bursts on /v2/orders. I have raised your tier ceiling to 2,000 req/min for two weeks so the ETL has headroom. Want me to schedule a 15-minute working session this week to walk your data team through the burst pattern?'
+          ]
+        }
+      },
+      {
+        id: 2,
+        sender: 'Tomás Riveira', email: 'tomas@helios.mx',
+        company: 'Helios Manufacturing', plan: 'Enterprise',
+        channel: 'Email', received: '1 hour ago',
+        subject: 'Renewal quote — we need to talk pricing',
+        body: 'Hi — we received the renewal quote yesterday. The 14% increase is hard to justify internally right now. We are open to a multi-year deal if that helps. Can you send a counter-proposal before Friday?\n\nBest, Tomás',
+        ai: {
+          category: 'Commercial · Renewal',
+          priority: 'High', sentiment: 'neutral', confidence: 88,
+          history: [
+            'At-risk health score (last 6 days quiet)',
+            'Procurement has asked for 20% off',
+            'Stage: Renewal · $9,800 MRR'
+          ],
+          thinking: [
+            'Reading commercial intent…',
+            'Pulling current contract terms',
+            'Modelling 2-year vs 3-year scenarios',
+            'Routing to Account Exec queue',
+            'Drafting reply…'
+          ],
+          replies: [
+            'Hi Tomás — thank you for the heads-up. I have pulled your current terms and modelled a couple of options: a two-year flat-rate at the existing price (zero increase) or a three-year deal with a 6% step-up in year three. I will send the counter-proposal by Thursday morning and have your AE, Priya, ready for a call before Friday. Anything specific procurement wants to see in the comparison?',
+            'Hi Tomás — appreciate the candour. I am routing this to Priya (your AE) immediately and will have a counter on your desk by Thursday end of day. We can absolutely do a multi-year structure — the typical shape is a three-year commitment with the increase deferred to year three. Want me to set a 30-minute slot Friday morning to walk through it with procurement?'
+          ]
+        }
+      },
+      {
+        id: 3,
+        sender: 'Aanya Patel', email: 'aanya@forge.capital',
+        company: 'Forge Capital', plan: 'Pro',
+        channel: 'In-app chat', received: '2 hours ago',
+        subject: 'Can we get SAML SSO on the Pro plan?',
+        body: 'Loving the product. Our security team is asking about SAML SSO before we expand seats from 12 to 40. Is this on the Pro plan or do we need to upgrade?',
+        ai: {
+          category: 'Product · Auth',
+          priority: 'Medium', sentiment: 'positive', confidence: 95,
+          history: [
+            'Pro plan, healthy account',
+            'Expansion signal: +28 seats requested',
+            'No prior auth-related tickets'
+          ],
+          thinking: [
+            'Classifying as expansion + product question',
+            'Checking plan-feature matrix',
+            'Surfacing upgrade path',
+            'Drafting reply…'
+          ],
+          replies: [
+            'Hi Aanya — great to hear it. SAML SSO sits on our Business and Enterprise plans (not Pro). Given you are looking at 40 seats, Business is usually the right fit and includes SCIM provisioning too. I can put you in touch with Jordan to walk through pricing — if SSO is the only blocker we can also enable it as a paid add-on on Pro for the next 30 days while you evaluate.',
+            'Hi Aanya — thanks for the kind words! SAML SSO is included on Business and above. For 40 seats Business is the natural step and gets you SCIM as well. Want me to enable a 14-day Business trial on your workspace so security can validate the setup before you commit?'
+          ]
+        }
+      },
+      {
+        id: 4,
+        sender: 'Lena Voss', email: 'lena@quillmedia.io',
+        company: 'Quill Media', plan: 'Starter',
+        channel: 'Email', received: '5 hours ago',
+        subject: 'Cancelling our subscription',
+        body: 'Hi — please cancel our subscription effective end of the billing cycle. We are consolidating onto another tool. No need for a save call.',
+        ai: {
+          category: 'Churn · Voluntary',
+          priority: 'High', sentiment: 'disappointed', confidence: 81,
+          history: [
+            'Starter plan, 8 months tenure',
+            'NPS detractor 21 days ago',
+            'Last login: 14 days ago'
+          ],
+          thinking: [
+            'Recognising explicit cancellation intent',
+            'User declined save call — respecting that',
+            'Pulling export options for their data',
+            'Drafting closing reply…'
+          ],
+          replies: [
+            'Hi Lena — understood, and thank you for being clear about not wanting a save call. I have queued the cancellation for the end of your current cycle (12 May). Before then, you can export workspace data in CSV or JSON from Settings → Data export. If you ever want a clean handoff document for the new tool, ping me and I will put one together.',
+            'Hi Lena — got it, no save call. Cancellation is set for end of cycle on 12 May and you will not be billed again. Your data is exportable from Settings → Data export until that date. If you change your mind in the next 90 days the workspace can be reactivated without losing history.'
+          ]
+        }
+      },
+      {
+        id: 5,
+        sender: 'Sam Okafor', email: 'sam@brambleco.com',
+        company: 'Bramble & Co', plan: 'Pro',
+        channel: 'Email', received: '8 hours ago',
+        subject: 'How do I share a dashboard read-only?',
+        body: 'Quick one — can I share a dashboard with a vendor without giving them edit access? Cheers, Sam',
+        ai: {
+          category: 'How-to · Sharing',
+          priority: 'Low', sentiment: 'positive', confidence: 97,
+          history: [
+            'Pro plan, healthy account',
+            'First ticket from this contact',
+            'Active 4h ago'
+          ],
+          thinking: [
+            'Trivially classifying as how-to',
+            'Pulling docs link',
+            'Drafting one-paragraph answer…'
+          ],
+          replies: [
+            'Hi Sam — yes, click Share on the dashboard, choose Anyone with the link, and toggle Permission to Can view. The vendor gets a read-only URL with no sign-in required. Full doc: docs.example.com/sharing/read-only. Let me know if you want it scoped to a specific email instead.',
+            'Hi Sam — easy one: open the dashboard, hit Share, set the access to Can view, and copy the link. View-only means no editing or comments. If you need an audit trail of who opened it, switch to Email-restricted instead — that requires sign-in.'
+          ]
+        }
+      }
+    ],
+
+    selectedId: 1,
+    aiState: {
+      status: 'idle',  /* idle | thinking | streaming | ready */
+      thinkingIdx: 0,
+      revealedTokens: 0,
+      replyIdx: 0,
+      runId: 0,
+      editing: false,
+      sent: {}         /* keyed by ticket id */
+    },
+    composer: '',
+
+    get selected() { return this.tickets.find(t => t.id === this.selectedId); },
+    get visibleSteps() {
+      if (!this.selected) return [];
+      return this.selected.ai.thinking.slice(0, this.aiState.thinkingIdx);
+    },
+    get currentStepLabel() {
+      if (!this.selected) return '';
+      return this.selected.ai.thinking[this.aiState.thinkingIdx] || '';
+    },
+    get streamingReply() {
+      if (!this.selected) return '';
+      const full = this.selected.ai.replies[this.aiState.replyIdx];
+      if (this.aiState.status === 'streaming') {
+        const tokens = full.split(' ');
+        return tokens.slice(0, this.aiState.revealedTokens).join(' ');
+      }
+      if (this.aiState.status === 'ready') return full;
+      return '';
+    },
+    get sentimentClass() {
+      const s = this.selected?.ai.sentiment;
+      if (s === 'positive')     return 'bg-emerald-100 text-emerald-700';
+      if (s === 'frustrated')   return 'bg-amber-100 text-amber-700';
+      if (s === 'disappointed') return 'bg-rose-100 text-rose-700';
+      return 'bg-slate-100 text-slate-700';
+    },
+    get priorityClass() {
+      const p = this.selected?.ai.priority;
+      if (p === 'High')   return 'bg-rose-100 text-rose-700';
+      if (p === 'Medium') return 'bg-amber-100 text-amber-700';
+      return 'bg-slate-100 text-slate-600';
+    },
+
+    /* --- Methods --- */
+    selectTicket(t) {
+      if (t.id === this.selectedId && this.aiState.status !== 'idle') return;
+      this.selectedId = t.id;
+      this.aiState.replyIdx = 0;
+      this.aiState.editing = false;
+      this.composer = '';
+      this.runAI();
+    },
+
+    runAI() {
+      const myRun = ++this.aiState.runId;
+      this.aiState.status = 'thinking';
+      this.aiState.thinkingIdx = 0;
+      this.aiState.revealedTokens = 0;
+      this.cycleThinking(myRun);
+    },
+
+    cycleThinking(runId) {
+      if (runId !== this.aiState.runId) return;
+      const t = this.selected;
+      if (!t) return;
+      if (this.aiState.thinkingIdx >= t.ai.thinking.length) {
+        this.aiState.status = 'streaming';
+        this.streamTokens(runId);
+        return;
+      }
+      setTimeout(() => {
+        if (runId !== this.aiState.runId) return;
+        this.aiState.thinkingIdx++;
+        this.cycleThinking(runId);
+      }, 480);
+    },
+
+    streamTokens(runId) {
+      if (runId !== this.aiState.runId) return;
+      const full = this.selected.ai.replies[this.aiState.replyIdx];
+      const tokens = full.split(' ');
+      if (this.aiState.revealedTokens >= tokens.length) {
+        this.aiState.status = 'ready';
+        this.composer = full;
+        return;
+      }
+      setTimeout(() => {
+        if (runId !== this.aiState.runId) return;
+        this.aiState.revealedTokens++;
+        this.streamTokens(runId);
+      }, 32);
+    },
+
+    regenerate() {
+      if (!this.selected) return;
+      const n = this.selected.ai.replies.length;
+      this.aiState.replyIdx = (this.aiState.replyIdx + 1) % n;
+      this.aiState.editing = false;
+      this.aiState.revealedTokens = 0;
+      this.aiState.status = 'streaming';
+      const myRun = ++this.aiState.runId;
+      this.streamTokens(myRun);
+    },
+
+    accept() {
+      if (!this.selected) return;
+      this.aiState.sent[this.selected.id] = true;
+      this.aiState.status = 'ready';
+    },
+
+    init() { this.runAI(); }
+  }"
+  class="mx-auto max-w-7xl px-6 py-8"
+>
+
+  <!-- HEADER -->
+  <header class="flex items-center justify-between mb-6 gap-4 flex-wrap">
+    <div class="flex items-center gap-3">
+      <div class="w-9 h-9 rounded-lg bg-slate-900 text-white grid place-items-center">
+        <!-- Sparkle glyph as SVG so we don't depend on emoji rendering. -->
+        <svg viewBox="0 0 24 24" class="w-5 h-5" fill="currentColor" aria-hidden="true">
+          <path d="M12 2l1.8 5.6L19 9l-5.2 1.4L12 16l-1.8-5.6L5 9l5.2-1.4L12 2zm6 12l1 2.5L21.5 17l-2.5 1L18 20.5 17 18l-2.5-1L17 16l1-2zM5 14l.8 2L8 16.8 5.8 17.6 5 19.5 4.2 17.6 2 16.8l2.2-.8L5 14z"/>
+        </svg>
+      </div>
+      <div>
+        <h1 class="text-xl font-semibold tracking-tight">Inbox Copilot</h1>
+        <p class="text-sm text-slate-500">Triage, suggested replies, one-click send. The AI is simulated for this demo.</p>
+      </div>
+    </div>
+    <div class="flex items-center gap-2 text-sm text-slate-500">
+      <span class="w-1.5 h-1.5 rounded-full bg-emerald-500"></span>
+      <span>Model: copilot-mini · simulated</span>
+    </div>
+  </header>
+
+  <!-- 3-COLUMN LAYOUT -->
+  <section class="grid grid-cols-1 lg:grid-cols-12 gap-4">
+
+    <!-- TICKET LIST -->
+    <aside class="lg:col-span-3 bg-white rounded-lg border border-slate-200">
+      <div class="p-3 border-b border-slate-200 flex items-center justify-between">
+        <span class="font-semibold tracking-tight text-sm">Inbox</span>
+        <span class="text-xs text-slate-500" x-text="tickets.length + ' open'"></span>
+      </div>
+      <ul class="divide-y divide-slate-100">
+        <template x-for="t in tickets" :key="t.id">
+          <li>
+            <button
+              @click="selectTicket(t)"
+              :class="selectedId === t.id ? 'bg-slate-50' : 'hover:bg-slate-50'"
+              class="w-full text-left p-3 transition"
+            >
+              <div class="flex items-baseline justify-between gap-2 mb-1">
+                <span class="text-sm font-medium truncate" x-text="t.sender"></span>
+                <span class="text-xs text-slate-400 shrink-0" x-text="t.received"></span>
+              </div>
+              <p class="text-xs text-slate-700 truncate" x-text="t.subject"></p>
+              <div class="mt-1.5 flex items-center gap-1.5">
+                <span class="text-[10px] px-1.5 py-0.5 rounded-full bg-slate-100 text-slate-600" x-text="t.ai.category"></span>
+                <span x-show="aiState.sent[t.id]" class="text-[10px] px-1.5 py-0.5 rounded-full bg-emerald-100 text-emerald-700">sent</span>
+              </div>
+            </button>
+          </li>
+        </template>
+      </ul>
+    </aside>
+
+    <!-- TICKET DETAIL -->
+    <main class="lg:col-span-5 bg-white rounded-lg border border-slate-200 p-5">
+      <template x-if="selected">
+        <div>
+          <div class="flex items-start justify-between gap-3 mb-3">
+            <div class="min-w-0">
+              <h2 class="font-semibold tracking-tight text-lg" x-text="selected.subject"></h2>
+              <p class="text-sm text-slate-500 mt-0.5">
+                <span class="font-medium text-slate-700" x-text="selected.sender"></span>
+                <span class="text-slate-400" x-text="' · ' + selected.email"></span>
+              </p>
+              <p class="text-xs text-slate-500 mt-0.5">
+                <span x-text="selected.company"></span>
+                <span class="text-slate-300 mx-1">·</span>
+                <span x-text="selected.plan + ' plan'"></span>
+                <span class="text-slate-300 mx-1">·</span>
+                <span x-text="selected.channel + ' · ' + selected.received"></span>
+              </p>
+            </div>
+          </div>
+          <div class="mt-4 text-slate-700 text-sm whitespace-pre-line leading-relaxed border-t border-slate-100 pt-4" x-text="selected.body"></div>
+        </div>
+      </template>
+    </main>
+
+    <!-- AI PANEL -->
+    <aside class="lg:col-span-4 space-y-4">
+
+      <!-- Analysis card -->
+      <div class="bg-white rounded-lg border border-slate-200 p-4">
+        <div class="flex items-center justify-between mb-3">
+          <div class="flex items-center gap-2">
+            <svg viewBox="0 0 24 24" class="w-4 h-4 text-violet-600" fill="currentColor" aria-hidden="true">
+              <path d="M12 2l1.8 5.6L19 9l-5.2 1.4L12 16l-1.8-5.6L5 9l5.2-1.4L12 2z"/>
+            </svg>
+            <h3 class="font-semibold tracking-tight text-sm">AI analysis</h3>
+          </div>
+          <span x-show="selected" class="text-[10px] tabular-nums text-slate-500"
+                x-text="'confidence ' + (selected ? selected.ai.confidence : 0) + '%'"></span>
+        </div>
+
+        <!-- Tag row -->
+        <template x-if="selected">
+          <div class="flex flex-wrap gap-1.5 mb-3">
+            <span class="text-[11px] px-2 py-0.5 rounded-full bg-slate-100 text-slate-700" x-text="selected.ai.category"></span>
+            <span class="text-[11px] px-2 py-0.5 rounded-full" :class="priorityClass" x-text="'priority: ' + selected.ai.priority.toLowerCase()"></span>
+            <span class="text-[11px] px-2 py-0.5 rounded-full" :class="sentimentClass" x-text="'sentiment: ' + selected.ai.sentiment"></span>
+          </div>
+        </template>
+
+        <!-- Customer history -->
+        <template x-if="selected">
+          <div>
+            <p class="text-xs uppercase tracking-wide text-slate-500 mb-1.5">Customer signal</p>
+            <ul class="text-xs text-slate-700 space-y-1">
+              <template x-for="h in selected.ai.history" :key="h">
+                <li class="flex gap-2">
+                  <span class="text-slate-400">•</span>
+                  <span x-text="h"></span>
+                </li>
+              </template>
+            </ul>
+          </div>
+        </template>
+      </div>
+
+      <!-- Thinking + reply card -->
+      <div class="bg-white rounded-lg border border-slate-200 p-4">
+        <div class="flex items-center justify-between mb-3">
+          <h3 class="font-semibold tracking-tight text-sm">Suggested reply</h3>
+          <span class="text-[10px] text-slate-500" x-text="aiState.status"></span>
+        </div>
+
+        <!-- Thinking trace: each step pops in. -->
+        <ol x-show="aiState.status === 'thinking' || aiState.status === 'streaming' || aiState.status === 'ready'" class="space-y-1 mb-3 text-xs">
+          <template x-for="(step, i) in visibleSteps" :key="i">
+            <li class="flex items-center gap-2 text-slate-600 pop-in">
+              <svg viewBox="0 0 24 24" class="w-3 h-3 text-emerald-500 shrink-0" fill="none" stroke="currentColor" stroke-width="3" aria-hidden="true">
+                <path d="M5 13l4 4L19 7"/>
+              </svg>
+              <span x-text="step"></span>
+            </li>
+          </template>
+          <li x-show="aiState.status === 'thinking' && currentStepLabel" class="flex items-center gap-2 text-slate-500 pop-in">
+            <svg class="animate-spin w-3 h-3 shrink-0" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+              <circle cx="12" cy="12" r="9" stroke="currentColor" stroke-opacity="0.25" stroke-width="3"/>
+              <path d="M21 12a9 9 0 0 0-9-9" stroke="currentColor" stroke-width="3" stroke-linecap="round"/>
+            </svg>
+            <span x-text="currentStepLabel"></span>
+          </li>
+        </ol>
+
+        <!-- Reply box: read-only stream until ready, then editable. -->
+        <div x-show="aiState.status === 'streaming' || aiState.status === 'ready'" class="rounded-md border border-slate-200 bg-slate-50/50 p-3 text-sm text-slate-800 leading-relaxed min-h-[140px]">
+          <template x-if="!aiState.editing">
+            <p class="whitespace-pre-line">
+              <span x-text="streamingReply"></span><span x-show="aiState.status === 'streaming'" class="caret text-slate-500"></span>
+            </p>
+          </template>
+          <template x-if="aiState.editing">
+            <textarea
+              x-model="composer"
+              rows="7"
+              class="w-full bg-transparent focus:outline-none resize-none text-sm leading-relaxed"
+            ></textarea>
+          </template>
+        </div>
+
+        <!-- Controls -->
+        <div class="flex items-center gap-2 mt-3" x-show="aiState.status === 'ready'">
+          <button
+            @click="regenerate()"
+            class="text-xs px-3 py-1.5 rounded-md border border-slate-300 hover:bg-slate-100 transition flex items-center gap-1.5"
+          >
+            <svg viewBox="0 0 24 24" class="w-3 h-3" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+              <path d="M4 4v6h6M20 20v-6h-6"/>
+              <path d="M20 8a8 8 0 0 0-14.93-2.5M4 16a8 8 0 0 0 14.93 2.5"/>
+            </svg>
+            Regenerate
+          </button>
+          <button
+            @click="aiState.editing = !aiState.editing"
+            :class="aiState.editing ? 'bg-slate-900 text-white border-slate-900' : 'border-slate-300 hover:bg-slate-100'"
+            class="text-xs px-3 py-1.5 rounded-md border transition"
+            x-text="aiState.editing ? 'Done' : 'Edit'"
+          ></button>
+          <div class="flex-1"></div>
+          <button
+            @click="accept()"
+            :disabled="aiState.sent[selectedId]"
+            :class="aiState.sent[selectedId] ? 'bg-emerald-100 text-emerald-700 cursor-not-allowed' : 'bg-slate-900 text-white hover:bg-slate-800'"
+            class="text-xs px-3 py-1.5 rounded-md transition"
+            x-text="aiState.sent[selectedId] ? 'Sent' : 'Accept and send'"
+          ></button>
+        </div>
+
+        <p class="text-[11px] text-slate-400 mt-3 leading-snug">
+          The agent draws on plan, ticket history, and product docs before drafting. Always review before sending.
+        </p>
+      </div>
+    </aside>
+  </section>
+
+  <footer class="mt-10 text-xs text-slate-400">
+    Self-contained Alpine.js + Tailwind demo. The 'AI' here is a setTimeout
+    chain: <code class="text-slate-500">runAI()</code> walks pre-written
+    thinking steps, then <code class="text-slate-500">streamTokens()</code>
+    reveals the reply word by word. Same pattern wires up to a real LLM by
+    swapping these for streaming-API callbacks.
+  </footer>
+</div>
+
+</body>
+</html>


### PR DESCRIPTION
Generates a self-contained single-file HTML demo or presentation using Alpine.js + Tailwind via CDN. Aimed at business and marketing users: the agent makes all edits, the user only opens the file in a browser.

Ships four reference patterns the skill draws on:
- catalogue.html: list-with-details baseline
- dashboard-with-tour.html: KPI dashboard with coaching-mark tour
- slide-deck.html: keyboard-driven deck with five layouts
- streaming-ai.html: simulated AI with thinking trace and streaming reply

Live worked examples at github.com/datashaman/alpine-onepager.