### PR TITLE
[codex] Add WIP GitHub workflow configurator skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,19 @@ Trello board health audit. Queries five dimensions of card data to identify thro
 /audit-trello board="My Board" since=2024-07-01
 ```
 
+### `/github-workflow-configurator`
+
+> **⚠️ WIP — not ready for use.** This skill is under active development and is not yet stable. Don't install it on a setup you care about.
+
+Interview-driven GitHub workflow setup for agent-assisted delivery. Helps choose and configure team composition, solo-vs-peer product review, architecture review gates, comment-triggered automation, GitHub Actions events, branch/label policy, and automation authority. Produces repo-specific config/docs/templates such as `.github/sdlc-agent-workflow.yml`, Actions event routing, issue templates, and PR templates.
+
+**Usage:**
+```
+/github-workflow-configurator configure this repo for solo PO workflow
+/github-workflow-configurator set up comment-triggered agent automation
+/github-workflow-configurator design a GitHub Actions approach for PO + Architect + remote agents
+```
+
 ### `/onepager`
 
 Generate a self-contained single-file HTML demo or presentation using Alpine.js + Tailwind via CDN. Emailable, double-clickable, no build step. Aimed at business and marketing users putting an interactive thing in front of a stakeholder without booking engineering — the agent makes all edits, the user only opens the file in a browser.

--- a/skills/github-workflow-configurator/SKILL.md
+++ b/skills/github-workflow-configurator/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: github-workflow-configurator
+description: |
+  Interview a user about team composition, review gates, GitHub automation preferences,
+  and agent execution style, then configure a repo-specific GitHub workflow approach.
+  Use when asked to set up GitHub Actions/events, comment-triggered automation,
+  PR review gates, solo-vs-team review modes, branch/label policy, or agent workflow automation.
+---
+
+# GitHub Workflow Configurator
+
+> **WIP — not ready for use.** This skill is under active development and is not yet stable. Do not install it on a setup you care about.
+
+Design and configure a GitHub-based workflow for agent-assisted delivery.
+
+The skill adapts to how the user actually works: solo, with another PO, with an architect, with remote agents, or with a broader engineering team. Do not assume one universal workflow.
+
+## Core Rule
+
+Interview first, configure second.
+
+If the repo already has workflow docs or automation, inspect them before asking questions. If the user's desired mode is already clear, ask only for missing decisions.
+
+## Inputs To Inspect
+
+Prefer local repo context when available:
+
+- `.github/workflows/`
+- `.github/ISSUE_TEMPLATE/`
+- `.github/pull_request_template.md`
+- `.github/CODEOWNERS`
+- repo docs mentioning issues, PRs, agents, state, labels, reviews, or automation
+- existing workflow config files such as `.github/sdlc-agent-workflow.yml`
+- current branch, open PR, and issue context when relevant
+
+Use `gh` or a GitHub connector when current remote settings, labels, branch protection, PR metadata, or Actions runs matter. Verify before editing.
+
+## Interview
+
+Ask concise questions. Prefer one pass with defaults the user can correct.
+
+Required decisions:
+
+- Team composition: `solo`, `two-po`, `po-architect`, `full-team`, or custom.
+- Product review mode: `peer-po-review` or `self-comment-acceptance`.
+- Architecture review mode: `architect-review`, `architect-comment-acceptance`, or `none`.
+- Agent execution: `local`, `remote`, or `hybrid`.
+- Automation trigger style: `workflow_dispatch`, `issue_comment`, `pull_request_review`, `pull_request`, or mixed.
+- Automation authority: `observe-only`, `comment-only`, `commit-to-branch`, or `open-pr`.
+- Gate strictness: `lightweight`, `standard`, or `strict`.
+
+Useful follow-ups:
+
+- Should comments trigger automation? If yes, what exact command phrases?
+- Can automation push commits to PR branches?
+- Should draft PRs be used before product review?
+- Should labels be sparse queue signals or full state labels?
+- Are branch protection rules already enforced?
+- Which humans must remain in the approval loop?
+
+## Configuration Output
+
+Produce a short recommendation first, then implement if asked or if the user clearly requested configuration.
+
+Recommended config shape:
+
+```yaml
+workflow:
+  team_composition: "solo"
+  agent_execution: "hybrid"
+  gate_strictness: "standard"
+
+reviews:
+  product_review_mode: "self-comment-acceptance"
+  architecture_review_mode: "architect-review"
+
+automation:
+  trigger_style: "issue_comment"
+  authority: "commit-to-branch"
+  command_prefix: "/agent"
+
+github:
+  branch_policy: "draft-pr-first"
+  labels: "sparse"
+  required_checks: []
+```
+
+If writing files, prefer:
+
+- `.github/sdlc-agent-workflow.yml` for policy/configuration.
+- `.github/workflows/sdlc-agent-events.yml` for Actions event routing.
+- `.github/ISSUE_TEMPLATE/change.yml` for change requests.
+- `.github/pull_request_template.md` for PR handoff context.
+- docs updates that explain the chosen mode and event triggers.
+
+## Decision Rules
+
+- Preserve GitHub native state where possible: PR draft/ready, reviews, merged PRs, and closed issues should not be duplicated with labels.
+- Use comments as event triggers only when the command phrases are explicit and auditable.
+- Use PR reviews for human gates when possible.
+- Use `Product review:` PR comments as an accepted fallback when the PR author cannot approve their own PR or no peer PO is available.
+- Keep labels sparse unless the team explicitly wants labels as a queueing surface.
+- Do not let automation merge code unless branch protection and required checks make that safe.
+- Do not let automation change product intent silently. Require an explicit comment, review, issue update, or config change.
+
+## Reference Loading
+
+Load only what is needed:
+
+- `references/review-modes.md` for solo vs team review-mode configuration.
+- `references/github-events.md` for Actions events, permissions, and trigger patterns.
+- `references/config-templates.md` for example config, issue templates, PR templates, and workflow snippets.
+
+## Implementation Checklist
+
+When configuring a repo:
+
+- [ ] Inspect existing GitHub workflow files and docs.
+- [ ] Interview for missing decisions.
+- [ ] Propose a concrete mode and explain tradeoffs.
+- [ ] Add or update config/docs/templates.
+- [ ] Add or update GitHub Actions only when automation is requested.
+- [ ] Keep permissions least-privilege.
+- [ ] Validate YAML syntax where possible.
+- [ ] Summarize chosen modes, files changed, and manual GitHub settings still needed.
+
+## Manual Settings
+
+Some settings may require GitHub UI or API access:
+
+- branch protection rules
+- required checks
+- GitHub App installation permissions
+- repository Actions permissions
+- rulesets
+- labels
+
+If you cannot apply these directly, output exact settings for the user to apply.

--- a/skills/github-workflow-configurator/agents/openai.yaml
+++ b/skills/github-workflow-configurator/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "GitHub Workflow Configurator"
+  short_description: "Configure GitHub Actions, events, reviews, and agent workflow modes."
+  default_prompt: "Use $github-workflow-configurator to interview me and configure this repo's GitHub automation workflow."
+policy:
+  allow_implicit_invocation: true

--- a/skills/github-workflow-configurator/references/config-templates.md
+++ b/skills/github-workflow-configurator/references/config-templates.md
@@ -1,0 +1,136 @@
+# Configuration Templates
+
+Adapt these templates to the repository. Do not copy blindly.
+
+## Workflow Policy
+
+Path: `.github/sdlc-agent-workflow.yml`
+
+```yaml
+workflow:
+  team_composition: "solo"
+  agent_execution: "hybrid"
+  gate_strictness: "standard"
+
+reviews:
+  product_review_mode: "self-comment-acceptance"
+  architecture_review_mode: "architect-review"
+
+automation:
+  trigger_style: "issue_comment"
+  authority: "comment-only"
+  command_prefix: "/agent"
+  allowed_comment_prefixes:
+    - "/agent"
+    - "Product review:"
+    - "Architecture review:"
+
+github:
+  branch_policy: "draft-pr-first"
+  labels: "sparse"
+  required_checks: []
+```
+
+## Issue Template
+
+Path: `.github/ISSUE_TEMPLATE/change.yml`
+
+```yaml
+name: Change
+description: Request a workflow change
+title: "[Change]: "
+labels: []
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What problem should this change solve?
+    validations:
+      required: true
+  - type: textarea
+    id: desired-outcome
+    attributes:
+      label: Desired outcome
+      description: What should be true when this is done?
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: Checklist or scenarios for acceptance.
+    validations:
+      required: true
+```
+
+## PR Template
+
+Path: `.github/pull_request_template.md`
+
+```markdown
+## Issue
+
+Closes #
+
+## Summary
+
+## Workflow
+
+- Change folder:
+- Current state:
+- Product review evidence:
+- Architecture review evidence:
+
+## Validation
+```
+
+## Comment Event Workflow
+
+Path: `.github/workflows/sdlc-agent-events.yml`
+
+```yaml
+name: SDLC Agent Events
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+  workflow_dispatch:
+    inputs:
+      command:
+        description: "Agent command"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  route:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Route event
+        run: |
+          echo "Event: ${{ github.event_name }}"
+          echo "Actor: ${{ github.actor }}"
+```
+
+Before adding write steps, decide:
+
+- which actors are allowed
+- which command prefixes are accepted
+- whether the workflow can push commits
+- how idempotency is recorded
+
+## Sparse Labels
+
+Recommended labels:
+
+- `implementing`: implementation work is active
+- `needs-product-input`: blocked on product clarification
+
+Avoid duplicating native GitHub state with labels for draft, ready, approved, merged, closed, or product review.

--- a/skills/github-workflow-configurator/references/github-events.md
+++ b/skills/github-workflow-configurator/references/github-events.md
@@ -1,0 +1,151 @@
+# GitHub Events And Automation
+
+Use the smallest event surface that supports the workflow.
+
+## Common Events
+
+### `workflow_dispatch`
+
+Manual trigger.
+
+Use when:
+
+- automation should be deliberate
+- the team is still dogfooding
+- permissions are sensitive
+
+Strengths: safe, explicit, easy to test.
+
+Weaknesses: less ergonomic for conversational workflows.
+
+### `issue_comment`
+
+Runs when a comment is created or edited on an issue or PR.
+
+Use when:
+
+- comments are command triggers
+- solo product acceptance uses `Product review:` comments
+- agents should react to `/agent ...` commands
+
+Guardrails:
+
+- check `github.event.issue.pull_request` before treating the comment as a PR comment
+- require exact prefixes, such as `/agent implement`, `Product review:`, or `Architecture review:`
+- check commenter permissions before write actions
+- ignore comments from bots unless explicitly allowed
+
+### `pull_request_review`
+
+Runs when a PR review is submitted, edited, or dismissed.
+
+Use when:
+
+- independent human gates should trigger automation
+- `Product review:` or `Architecture review:` review bodies are canonical gate evidence
+
+Guardrails:
+
+- check review state: `approved`, `changes_requested`, or `commented`
+- inspect review body prefix when the workflow multiplexes product and architecture gates
+- do not treat review comments as equivalent to an approval unless configured
+
+### `pull_request`
+
+Runs for PR lifecycle changes.
+
+Useful actions:
+
+- `opened`
+- `ready_for_review`
+- `synchronize`
+- `reopened`
+- `closed`
+
+Use when:
+
+- validation should run on every PR update
+- ready-for-review should route a queue
+- merge/close should update cleanup or reporting
+
+Guardrails:
+
+- avoid mutating code on every `synchronize`
+- do not infer human approval from ready-for-review
+
+### `issues`
+
+Runs for issue lifecycle changes.
+
+Use when:
+
+- new issues should be converted into change branches or planning artifacts
+- labels are queue signals
+- issue close should trigger cleanup
+
+Guardrails:
+
+- avoid creating duplicate PRs from edited issues
+- use idempotency markers such as issue comments, branch names, or config state
+
+## Permissions
+
+Start least-privilege:
+
+```yaml
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+```
+
+Add only when needed:
+
+```yaml
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+  actions: read
+```
+
+Avoid broad write permissions for workflows that only observe or comment.
+
+## Command Comment Pattern
+
+Recommended command shape:
+
+```text
+/agent <verb> [target]
+```
+
+Examples:
+
+```text
+/agent create-change
+/agent move architecture-review
+/agent implement next-task
+/agent summarize
+```
+
+For gates, use explicit prefixes:
+
+```text
+Product review: accepted.
+Architecture review: approved for implementation.
+```
+
+## Idempotency
+
+Automation should be safe to rerun.
+
+Use one or more:
+
+- branch naming convention
+- PR link in issue comments
+- workflow config file
+- checked task boxes
+- hidden HTML comment marker in bot comments
+- state file transition record
+
+Do not rely only on chronological GitHub timeline events.

--- a/skills/github-workflow-configurator/references/review-modes.md
+++ b/skills/github-workflow-configurator/references/review-modes.md
@@ -1,0 +1,84 @@
+# Review Modes
+
+Use review modes to adapt one workflow to different team shapes.
+
+## Product Review
+
+### `peer-po-review`
+
+Use when another PO can review.
+
+- PO Agent prepares product artifacts.
+- PR is marked ready for product review.
+- Another PO submits a GitHub PR review with a body starting `Product review:`.
+- Workflow state links to the PR review.
+- The workflow moves from product draft/preparation to architecture review.
+
+Best for teams where product acceptance must be independent of the PR author.
+
+### `self-comment-acceptance`
+
+Use when working alone or when GitHub blocks self-approval.
+
+- PO Agent prepares product artifacts.
+- PR is marked ready for product review.
+- The PO posts a PR comment starting `Product review:`.
+- The comment can trigger automation.
+- Workflow state links to the comment and explains why comment acceptance was used.
+- The workflow moves from product draft/preparation to architecture review.
+
+Best for solo workflows and dogfooding. It is weaker than peer review, but explicit and auditable.
+
+## Architecture Review
+
+### `architect-review`
+
+Use when a human architect or tech lead can approve.
+
+- Architect Agent prepares architecture/task artifacts.
+- Architect submits a GitHub PR review with a body starting `Architecture review:`.
+- Workflow state links to the PR review.
+- Work moves to implementation or technical approval.
+
+### `architect-comment-acceptance`
+
+Use when a solo operator is also acting as architect.
+
+- Architect decision is recorded with an `Architecture review:` PR comment.
+- The comment can trigger automation.
+- Workflow state links to the comment.
+
+Use this only when independent technical approval is unavailable.
+
+### `none`
+
+Use for low-risk repos or experiments.
+
+- No separate architecture gate.
+- Product acceptance can move directly to implementation.
+- Automation should still require explicit command comments before commits or merges.
+
+## Gate Strictness
+
+### `lightweight`
+
+- Comment acceptance is allowed.
+- Automation can react to explicit comments.
+- Few required checks.
+- Useful for solo exploration and workflow design.
+
+### `standard`
+
+- PR reviews preferred for gates.
+- Comment fallback allowed only when documented.
+- Required checks run before merge.
+- Useful for small teams.
+
+### `strict`
+
+- Independent PR reviews required.
+- Comment fallback disabled.
+- Branch protection and required checks enforced.
+- Automation cannot merge and may only push to branches under clear command.
+
+Useful for production repositories.


### PR DESCRIPTION
## Summary

Adds a WIP `github-workflow-configurator` skill for interview-driven GitHub workflow setup.

The skill helps choose and configure:

- team composition and solo-vs-peer review modes
- product and architecture review gates
- GitHub Actions event triggers
- comment-triggered automation patterns
- automation authority and branch/label policy

## WIP status

This is explicitly marked WIP in the README and skill body, matching the warning style used by the harness skill.

## Validation

- `python3 -m ruff check skills/`
- `python3 -m ruff format --check skills/`
- YAML frontmatter and `agents/openai.yaml` parsed locally