### PR TITLE
cscript: Windows + PowerShell support

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,9 +106,9 @@ Trello board health audit. Queries five dimensions of card data to identify thro
 
 ### `/compile-task`
 
-Compile one-off task descriptions into reusable, self-contained executables so the LLM doesn't redo deterministic work each time. Picks bash for trivial file/shell ops or single-file `uv` Python (PEP 723 inline deps) for anything needing libraries. Scripts are registered in an appdata-backed catalogue and dispatched through a `cscript` binary the skill installs to a user-writable directory on `PATH`. From the second invocation onward the agent finds the script via `cscript which`, confirms with you, and runs it directly — no regeneration.
+Compile one-off task descriptions into reusable, self-contained executables so the LLM doesn't redo deterministic work each time. Picks bash for POSIX shell ops, PowerShell for Windows-native work, or single-file `uv` Python (PEP 723 inline deps) for anything needing libraries. Scripts are registered in an appdata-backed catalogue and dispatched through a `cscript` binary the skill installs to a user-writable directory on `PATH`. From the second invocation onward the agent finds the script via `cscript which`, confirms with you, and runs it directly — no regeneration.
 
-Ships with a `cscript` dispatcher (`list`, `which`, `run`, `show`, `edit`, `rm`, `state-dir`, `where`, `register`) and a smoke-test script. macOS and Linux only.
+Ships with a `cscript` dispatcher (`list`, `which`, `run`, `show`, `edit`, `rm`, `state-dir`, `where`, `register`), a Windows `cscript.cmd` wrapper, and a smoke-test script. Verified on macOS and Linux; Windows support is implemented (subprocess dispatch + `cscript.cmd` wrapper + PowerShell language option) and awaits validation by a Windows user.
 
 **Arguments:** None — describe the task in natural language and the skill decides whether to compile it, match an existing script, or skip.
 

--- a/skills/compile-task/README.md
+++ b/skills/compile-task/README.md
@@ -7,7 +7,7 @@ Compile one-off LLM tasks into reusable, self-contained executables so you stop 
 When you describe a task ("rename these photos by their EXIF date", "pull this GitHub issue's comments as markdown"), the skill:
 
 1. Checks a catalogue of previously-compiled scripts and offers to re-run an existing one if it matches.
-2. Otherwise picks the simplest language for the job — **bash** for trivial file/shell ops, **single-file uv Python** (PEP 723 inline deps) for anything that needs libraries.
+2. Otherwise picks the simplest language for the job — **bash** for POSIX shell ops, **PowerShell** for Windows-native or shell-y tasks on Windows, **single-file uv Python** (PEP 723 inline deps) as the cross-platform default for anything needing libraries.
 3. Writes the script, smoke-tests it, registers it in the catalogue, and runs it.
 
 From then on, the script is one command:
@@ -18,7 +18,7 @@ cscript run rename-by-exif-date ./photos
 
 ## The `cscript` dispatcher
 
-A single Python script installed on first use into a user-writable directory on `PATH`. It stores everything in an OS-correct appdata directory (`~/Library/Application Support/cscript/` on macOS, `~/.local/share/cscript/` on Linux). macOS and Linux only.
+A single Python script installed on first use into a user-writable directory on `PATH` (on Windows, paired with a small `cscript.cmd` wrapper). It stores everything in an OS-correct appdata directory: `~/Library/Application Support/cscript/` on macOS, `~/.local/share/cscript/` on Linux, `%LOCALAPPDATA%\cscript\` on Windows. Bash scripts on Windows require Git Bash or WSL.
 
 ```
 cscript list                       # show all registered scripts

--- a/skills/compile-task/SKILL.md
+++ b/skills/compile-task/SKILL.md
@@ -44,9 +44,22 @@ In order, before anything else:
 
    - Inspect existing `PATH` entries under the user's home directory and prefer one they already maintain.
    - If none is on `PATH`, ask the user where to put the binary rather than picking one for them.
-   - Copy `scripts/cscript` to `<chosen-dir>/cscript` and make it executable.
 
-   Currently macOS and Linux only. Windows is out of scope (the dispatcher uses `os.execv` and a `uv run` shebang).
+   Then install per OS:
+
+   - **macOS / Linux:** copy `scripts/cscript` to `<chosen-dir>/cscript` and make it executable.
+   - **Windows:** copy **both** `scripts/cscript` and `scripts/cscript.cmd` into the chosen directory. Windows resolves `cscript.cmd` via `PATHEXT`; the wrapper hands the extensionless source to `uv run --script`. Note: Windows ships `cscript.exe` (Windows Script Host) in `System32`; for our `cscript.cmd` to win, the chosen directory must appear in `PATH` before `C:\Windows\System32`. Verify by running this in PowerShell (substitute the chosen directory):
+
+     ```powershell
+     $paths = $env:Path -split ';'
+     $user = $paths.IndexOf('<chosen-dir>')
+     $sys  = $paths.IndexOf("$env:SystemRoot\System32")
+     if ($user -lt 0)                  { 'chosen dir not on PATH' }
+     elseif ($sys -ge 0 -and $user -gt $sys) { 'PATH ordering would let cscript.exe shadow cscript.cmd' }
+     else                              { 'OK' }
+     ```
+
+     If the check reports anything other than `OK`, tell the user how to fix it (add/reorder the entry in User PATH) and stop until they confirm.
 
 4. **Verify the install worked.** After copying, run `cscript --help` in a fresh shell invocation. If it does not resolve, the chosen directory is not on `PATH` in interactive shells — tell the user how to add it for their shell and stop. Do not proceed until they confirm `cscript --help` works.
 
@@ -72,8 +85,9 @@ If ambiguous (multiple plausible candidates) or no hits: show what you found and
 
 Pick the language using this decision rule, in order:
 
-1. **Bash** — if the task is purely file system, git, text munging with standard Unix tools (`jq`, `awk`, `sed`, `grep`, `find`, `rsync`), or a thin wrapper around an existing CLI the user has. No HTTP, no parsing structured formats beyond what `jq`/`yq` handle.
-2. **uv Python** — anything else. HTTP, HTML/XML parsing, image processing, anything pulling a library, anything where bash quoting would make you cry.
+1. **PowerShell** — if the task is Windows-native (registry, services, COM, Windows-specific filesystem APIs) **or** if the user is on Windows without Git Bash/WSL and the task is shell-y enough that bash would be the POSIX choice. `pwsh` (PowerShell Core) runs on macOS and Linux too, so this is also fine for cross-platform shell tasks if the user already uses PowerShell.
+2. **Bash** — if the task is purely file system, git, text munging with standard Unix tools (`jq`, `awk`, `sed`, `grep`, `find`, `rsync`), or a thin wrapper around an existing CLI the user has. No HTTP, no parsing structured formats beyond what `jq`/`yq` handle. On Windows, bash scripts need Git Bash or WSL.
+3. **uv Python** — anything else. HTTP, HTML/XML parsing, image processing, anything pulling a library, anything where bash quoting would make you cry. The cross-platform default when in doubt.
 
 Pick a name: short verb-object, kebab-case, no language suffix. `resize-pngs`, not `resize_pngs.sh`. `rename-by-exif-date`, not `photo_renamer.py`. The dispatcher hides the extension.
 
@@ -81,8 +95,9 @@ Read the matching template from `references/` before writing:
 
 - `references/bash-template.sh`
 - `references/uv-python-template.py`
+- `references/powershell-template.ps1`
 
-Both templates have the structural skeleton (shebang, header comment with NAME/DESC/USAGE, `--help`, arg parsing, error handling). Fill in the implementation only.
+All three templates have the structural skeleton (shebang, header comment with NAME/DESC/USAGE, `--help`/`-Help`, arg parsing, error handling). Fill in the implementation only.
 
 ### 4. Write and smoke-test
 
@@ -98,12 +113,12 @@ cscript register \
   --source <temp-path> \
   --name <name> \
   --description "<one-line, present tense, no trailing period>" \
-  --language <bash|python> \
+  --language <bash|python|powershell> \
   --args-help "<one-line usage>" \
   [--read-only]
 ```
 
-The dispatcher derives the filename automatically (`<name>.sh` for bash, `<name>.py` for python), moves the file from `--source` into the appdata `scripts/` directory, chmods it to 0755, archives any prior version, and prints the final path.
+The dispatcher derives the filename automatically (`<name>.sh` for bash, `<name>.py` for python, `<name>.ps1` for powershell), moves the file from `--source` into the appdata `scripts/` directory, makes it executable on POSIX, archives any prior version, and prints the final path.
 
 ### 6. Run
 
@@ -131,6 +146,7 @@ The dispatcher is installed wherever the user keeps personal binaries on `PATH` 
 
 - macOS: `~/Library/Application Support/cscript/`
 - Linux: `~/.local/share/cscript/`
+- Windows: `%LOCALAPPDATA%\cscript\`
 
 Subcommands:
 

--- a/skills/compile-task/references/powershell-template.ps1
+++ b/skills/compile-task/references/powershell-template.ps1
@@ -1,0 +1,47 @@
+#!/usr/bin/env pwsh
+# NAME: example-name
+# DESC: One-line description in present tense, no trailing period
+# USAGE: example-name <required-arg> [-Flag]
+#
+# Replace this header when generating. Keep NAME / DESC / USAGE — `cscript show`
+# prints them above the source. The DESC line is what `cscript which` matches.
+
+[CmdletBinding()]
+param(
+    [Parameter(Position = 0)]
+    [string]$Required,
+
+    [switch]$Flag,
+
+    [Alias('h')]
+    [switch]$Help
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Show-Usage {
+    @'
+Usage: example-name <required-arg> [-Flag]
+
+Description here.
+
+Args:
+  required-arg    What it is
+
+Flags:
+  -Flag           What it does
+  -h, -Help       Show this help
+'@
+}
+
+if ($Help) {
+    Show-Usage
+    exit 0
+}
+
+if (-not $Required) {
+    [Console]::Error.WriteLine((Show-Usage))
+    exit 2
+}
+
+# --- implementation below ---

--- a/skills/compile-task/scripts/cscript
+++ b/skills/compile-task/scripts/cscript
@@ -29,7 +29,7 @@ ARCHIVE = SCRIPTS / ".archive"
 STATE = DATA / "state"
 INDEX = DATA / "index.json"
 
-EXT = {"bash": ".sh", "python": ".py"}
+EXT = {"bash": ".sh", "python": ".py", "powershell": ".ps1"}
 
 
 def ensure_dirs() -> None:
@@ -127,6 +127,27 @@ def confirm_run(item: dict) -> bool:
     return answer in ("y", "yes")
 
 
+def build_invocation(path: Path, language: str, passthrough: list[str]) -> list[str]:
+    """Return the argv for running `path` as `language`, with `passthrough` appended."""
+    if sys.platform == "win32":
+        if language == "python" or path.suffix == ".py":
+            return ["uv", "run", "--script", str(path), *passthrough]
+        if language == "bash" or path.suffix == ".sh":
+            # Requires Git Bash, WSL, or another bash on PATH.
+            return ["bash", str(path), *passthrough]
+        if language == "powershell" or path.suffix == ".ps1":
+            return [
+                "pwsh",
+                "-NoProfile",
+                "-ExecutionPolicy",
+                "Bypass",
+                "-File",
+                str(path),
+                *passthrough,
+            ]
+    return [str(path), *passthrough]
+
+
 def cmd_run(args: argparse.Namespace) -> int:
     item = resolve(args.name)
     if item is None:
@@ -138,9 +159,16 @@ def cmd_run(args: argparse.Namespace) -> int:
     if not args.yes and not confirm_run(item):
         print("cscript: aborted", file=sys.stderr)
         return 1
-    if not os.access(path, os.X_OK):
-        path.chmod(0o755)
-    os.execv(str(path), [str(path), *args.args])
+    if sys.platform != "win32":
+        if not os.access(path, os.X_OK):
+            path.chmod(0o755)
+        os.execv(str(path), [str(path), *args.args])
+    argv = build_invocation(path, item.get("language", ""), args.args)
+    try:
+        return subprocess.run(argv).returncode
+    except FileNotFoundError as exc:
+        print(f"cscript: {exc.filename or argv[0]} not found on PATH", file=sys.stderr)
+        return 127
 
 
 def cmd_show(args: argparse.Namespace) -> int:

--- a/skills/compile-task/scripts/cscript.cmd
+++ b/skills/compile-task/scripts/cscript.cmd
@@ -1,0 +1,6 @@
+@echo off
+rem Windows wrapper for the cscript dispatcher.
+rem Install BOTH this file and the extensionless `cscript` source into the
+rem same directory on PATH. Windows resolves cscript.cmd via PATHEXT; this
+rem then hands the PEP 723 source to `uv run --script`.
+uv run --script "%~dp0cscript" %*


### PR DESCRIPTION
## Summary

Extend the `compile-task` skill to actually run on Windows, and add PowerShell as a third script language alongside bash and uv-Python.

- **Windows dispatch**: `cmd_run` now branches on `sys.platform`. POSIX keeps the `os.execv` path; Windows uses `subprocess.run(...).returncode` so exit codes propagate cleanly.
- **`cscript.cmd` wrapper**: Windows resolves `.cmd` via `PATHEXT`. The wrapper hands the extensionless source to `uv run --script` using `%~dp0` so the install dir is self-locating.
- **PowerShell language**: new `references/powershell-template.ps1` (with `#!/usr/bin/env pwsh` shebang so POSIX `os.execv` works), `EXT['powershell'] = '.ps1'`, and a Windows invocation through `pwsh -NoProfile -ExecutionPolicy Bypass -File`.
- **Three-way decision rule** in SKILL.md: PowerShell for Windows-native or shell-y-on-Windows; bash for POSIX shell ops; uv-Python as the cross-platform default.
- **Bootstrap docs** now per-OS, including a concrete PowerShell snippet the agent can run to verify the chosen install directory precedes `System32` in PATH (so `cscript.cmd` isn't shadowed by Windows Script Host's `cscript.exe`).
- **Bash-on-Windows caveat** documented: needs Git Bash or WSL; if neither is available the skill prefers Python.

## Files

```
M README.md                                       # softened cross-platform claim
M skills/compile-task/README.md                   # mention PowerShell + Windows wrapper
M skills/compile-task/SKILL.md                    # per-OS install, 3-way rule, PATH check
M skills/compile-task/scripts/cscript             # Windows dispatch, pwsh routing, EXT
A skills/compile-task/scripts/cscript.cmd         # Windows wrapper
A skills/compile-task/references/powershell-template.ps1
```

## Test plan

- [x] `scripts/smoke-test.sh` still green on macOS — bash and Python paths unchanged.
- [ ] **Windows / PowerShell validation by a Windows user.** I don't have access to a Windows host or `pwsh` locally; the implementation follows the spec but has not been exercised. Reviewers on Windows: install via the bootstrap steps, register a trivial `.ps1`, run it through `cscript run`, and confirm the PATH-ordering check works as written.

## Notes / known asymmetries

- PowerShell on POSIX goes through the standard `os.execv` path (relying on the `#!/usr/bin/env pwsh` shebang), so it does **not** get `-NoProfile -ExecutionPolicy Bypass`. POSIX has no ExecutionPolicy to bypass, but the lack of `-NoProfile` means user profiles load on every run. Acceptable for now; document if it bites.
- Windows `cscript.exe` (Windows Script Host) is a real name collision in `System32`. The bootstrap PATH-ordering check is the mitigation, not a rename — the consistent name across OSes is worth more than avoiding the shadow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)